### PR TITLE
Use structopt for parsing CLI arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tower-util = "0.1"
 k8s-openapi = { version = "0.4.0", features = ["v1_13"] }
 reqwest = "0.9.18"
 clap = "2.33.0"
+structopt = "0.2"
 arrow = { git = "https://github.com/apache/arrow" }
 datafusion = { git = "https://github.com/apache/arrow" }
 kube = "0.14"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -41,7 +41,7 @@ pub struct CreateCluster {
         long = "volumes",
         help = "Persistent Volumes to mount into the executor pods. Syntax should be '<pv-name>:<mount-path>'"
     )]
-    pub volumes: Vec<String>,
+    pub volumes: Vec<cluster::Volume>,
 
     #[structopt(
         name = "image",

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,139 +1,122 @@
 //! Ballista CLI
 
-use clap::{App, Arg, ArgMatches, SubCommand};
 use std::time::Instant;
+use structopt::StructOpt;
 
 use ballista::cluster;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "ballista", about = "Distributed compute platform")]
+pub struct Opt {
+    #[structopt(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum Command {
+    #[structopt(name = "create-cluster", about = "Create a ballista cluster")]
+    CreateCluster(CreateCluster),
+
+    #[structopt(name = "delete-cluster", about = "Delete a ballista cluster")]
+    DeleteCluster(DeleteCluster),
+
+    #[structopt(name = "run", about = "Execute a Ballista application")]
+    Run(Run),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct CreateCluster {
+    #[structopt(short = "n", long = "name", help = "Ballista cluster name")]
+    pub name: String,
+
+    #[structopt(
+        short = "e",
+        long = "num-executors",
+        help = "number of executor pods to create"
+    )]
+    pub num_executors: usize,
+
+    #[structopt(
+        short = "v",
+        long = "volumes",
+        help = "Persistent Volumes to mount into the executor pods. Syntax should be '<pv-name>:<mount-path>'"
+    )]
+    pub volumes: Vec<String>,
+
+    #[structopt(
+        name = "image",
+        short = "i",
+        help = "Custom Ballista Docker image to use for executors"
+    )]
+    pub image: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct DeleteCluster {
+    #[structopt(short = "n", long = "name", help = "Ballista cluster name")]
+    pub name: String,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Run {
+    #[structopt(short = "n", long = "name", help = "Ballista cluster name")]
+    pub name: String,
+
+    #[structopt(name = "image", short = "i", help = "Docker image for application pod")]
+    pub image: String,
+}
 
 pub fn main() {
     ::env_logger::init();
 
     let now = Instant::now();
-
-    let matches = App::new("Ballista")
-        .version("0.1.0")
-        .author("Andy Grove <andygrove73@gmail.com>")
-        .about("Distributed compute platform")
-        .subcommand(
-            SubCommand::with_name("create-cluster")
-                .about("Create a ballista cluster")
-                .arg(
-                    Arg::with_name("name")
-                        .required(true)
-                        .takes_value(true)
-                        .short("n")
-                        .long("name")
-                        .help("Ballista cluster name"),
-                )
-                .arg(
-                    Arg::with_name("executors")
-                        .short("e")
-                        .long("num-executors")
-                        .required(true)
-                        .takes_value(true)
-                        .help("number of executor pods to create"),
-                )
-                .arg(
-                    Arg::with_name("volumes")
-                        .required(false)
-                        .multiple(true)
-                        .takes_value(true)
-                        .short("v")
-                        .long("volumes")
-                        .help("Persistent Volumes to mount into the executor pods. Syntax should be '<pv-name>:<mount-path>'"),
-                )
-                .arg(
-                    Arg::with_name("image")
-                        .required(false)
-                        .takes_value(true)
-                        .short("i")
-                        .long("image")
-                        .help("Custom Ballista Docker image to use for executors"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("delete-cluster")
-                .about("Delete a ballista cluster")
-                .arg(
-                    Arg::with_name("name")
-                        .required(true)
-                        .takes_value(true)
-                        .short("n")
-                        .long("name")
-                        .help("Ballista cluster name"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("run")
-                .about("Execute a ballista application")
-                .arg(
-                    Arg::with_name("name")
-                        .required(true)
-                        .takes_value(true)
-                        .short("n")
-                        .long("name")
-                        .help("Ballista cluster name"),
-                )
-                .arg(
-                    Arg::with_name("image")
-                        .required(true)
-                        .takes_value(true)
-                        .short("i")
-                        .long("image")
-                        .help("Docker image for application pod"),
-                ),
-        )
-        .get_matches();
-
-    match matches.subcommand() {
-        ("create-cluster", Some(subcommand_matches)) => create_cluster(subcommand_matches),
-        ("delete-cluster", Some(subcommand_matches)) => delete_cluster(subcommand_matches),
-        ("run", Some(subcommand_matches)) => execute(subcommand_matches),
-        _ => {
-            println!("Invalid subcommand");
-            std::process::exit(-1);
+    let opt = Opt::from_args();
+    let subcommand = match opt.cmd {
+        Command::CreateCluster(c) => {
+            create_cluster(c);
+            "create-cluster"
         }
-    }
+        Command::DeleteCluster(d) => {
+            delete_cluster(d);
+            "delete-cluster"
+        }
+        Command::Run(r) => {
+            execute(r);
+            "run"
+        }
+    };
 
     println!(
         "Executed subcommand {} in {} seconds",
-        matches.subcommand_name().unwrap(),
+        subcommand,
         now.elapsed().as_millis() as f64 / 1000.0
     );
 }
 
-fn create_cluster(matches: &ArgMatches<'_>) {
-    let cluster_name = matches.value_of("name").unwrap().to_string();
-    let replicas = matches
-        .value_of("executors")
-        .unwrap()
-        .parse::<usize>()
-        .unwrap();
-    let volumes = matches
-        .values_of("volumes")
-        .map(|v| v.map(|i| i.to_string()).collect());
-    let image = matches.value_of("image").map(|i| i.to_string());
+fn create_cluster(args: CreateCluster) {
+    let volumes = if args.volumes.is_empty() {
+        None
+    } else {
+        Some(args.volumes)
+    };
     let namespace = "default".to_string();
 
-    cluster::ClusterBuilder::new(cluster_name, namespace, replicas)
-        .image(image)
+    cluster::ClusterBuilder::new(args.name, namespace, args.num_executors)
+        .image(args.image)
         .volumes(volumes)
         .create()
         .expect("Could not create cluster");
 }
 
-fn delete_cluster(matches: &ArgMatches<'_>) {
-    let cluster_name = matches.value_of("name").unwrap();
+fn delete_cluster(args: DeleteCluster) {
     let namespace = "default";
-    cluster::delete_cluster(cluster_name, namespace).expect("Could not delete cluster");
+    cluster::delete_cluster(&args.name, namespace).expect("Could not delete cluster");
 }
 
-fn execute(matches: &ArgMatches<'_>) {
-    let cluster_name = matches.value_of("name").unwrap();
-    let image = matches.value_of("image").unwrap();
+fn execute(args: Run) {
     let namespace = "default";
 
-    let pod_name = format!("ballista-{}-app", cluster_name);
+    let pod_name = format!("ballista-{}-app", args.name);
 
-    cluster::create_ballista_application(namespace, pod_name, image.to_string()).unwrap();
+    cluster::create_ballista_application(namespace, pod_name, args.image).unwrap();
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -159,7 +159,7 @@ impl std::str::FromStr for Volume {
     type Err = BallistaError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut split = s.splitn(2, ":");
+        let mut split = s.splitn(2, ':');
         let name = split
             .next()
             .ok_or_else(|| BallistaError::General(format!(
@@ -348,8 +348,7 @@ impl ClusterBuilder {
                                 ..Default::default()
                             }]),
                             volume_mounts: self.volumes.as_ref().map(|vs| {
-                                vs.clone()
-                                    .into_iter()
+                                vs.iter()
                                     .map(|v| VolumeMount {
                                         name: v.name.clone(),
                                         mount_path: v.mount_path.clone(),
@@ -360,8 +359,7 @@ impl ClusterBuilder {
                             ..Default::default()
                         }],
                         volumes: self.volumes.as_ref().map(|vs| {
-                            vs.clone()
-                                .into_iter()
+                            vs.iter()
                                 .map(|v| Volume {
                                     name: v.name.clone(),
                                     persistent_volume_claim: Some(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 //! Ballista error types
 
-use std::io;
-use std::result;
+use std::{fmt, io, result};
 
 use arrow::error::ArrowError;
 use datafusion::error::ExecutionError;
@@ -22,6 +21,22 @@ pub enum BallistaError {
     HttpError(http::Error),
     KubeAPIRequestError(k8s_openapi::RequestError),
     KubeAPIResponseError(k8s_openapi::ResponseError),
+}
+
+impl fmt::Display for BallistaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BallistaError::NotImplemented(s) => s.clone(),
+            BallistaError::General(s) => s.clone(),
+            BallistaError::DataFusionError(e) => format!("{:?}", e),
+            BallistaError::ReqwestError(e) => e.to_string(),
+            BallistaError::IoError(e) => e.to_string(),
+            BallistaError::HttpError(e) => e.to_string(),
+            BallistaError::KubeAPIRequestError(e) => e.to_string(),
+            BallistaError::KubeAPIResponseError(e) => e.to_string(),
+        };
+        f.write_str(&s)
+    }
 }
 
 impl From<String> for BallistaError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,7 @@ impl fmt::Display for BallistaError {
         let s = match self {
             BallistaError::NotImplemented(s) => s.clone(),
             BallistaError::General(s) => s.clone(),
+            BallistaError::ArrowError(e) => format!("{:?}", e),
             BallistaError::DataFusionError(e) => format!("{:?}", e),
             BallistaError::ReqwestError(e) => e.to_string(),
             BallistaError::IoError(e) => e.to_string(),


### PR DESCRIPTION
This is to show how the CLI module may look if structopt is used instead of base clap.

This is based on #55 and so shouldn't be merged until that PR is (it should be simple to change this PR in case #55 isn't merged).

Fixes #60.