### PR TITLE
Kotlin: Update SQL Tokenizer for Comparison Operators

### DIFF
--- a/jvm/sql/src/main/kotlin/SqlTokenizer.kt
+++ b/jvm/sql/src/main/kotlin/SqlTokenizer.kt
@@ -66,20 +66,17 @@ class SqlTokenizer(val sql: String) {
             val start = i
             i++
 
-            if (listOf('<').contains(sql[start]) && listOf('>').contains(sql[i])) {
-                // Confirm compound operator: `<>`
-                i++
-            } else if (listOf('>', '<', '!').contains(sql[start]) && '=' == sql[i]) {
-                // Confirm compound operators: `>=`, `<=`, and `!=`
-                i++
+            val compoundOperator = sql.substring(start, i + 1)
+            if (listOf("<=", ">=", "<>", "!=").contains(compoundOperator)) {
+              i++
+              return OperatorToken (compoundOperator)
             }
 
-            if (sql[start] == '!' && start == i - 1) {
+            if (sql[start] == '!') {
                 throw IllegalStateException("Invalid character '${sql[start]}' at position $start in '$sql' expected: !=")
             }
 
-            val str = sql.substring(start, i)
-            return OperatorToken(str)
+            return OperatorToken(sql.substring(start, i))
 
         } else if (sql[i] == '\'') {
             //TODO handle escaped quotes in string

--- a/jvm/sql/src/main/kotlin/SqlTokenizer.kt
+++ b/jvm/sql/src/main/kotlin/SqlTokenizer.kt
@@ -62,12 +62,24 @@ class SqlTokenizer(val sql: String) {
                 return IdentifierToken(s)
             }
 
-        } else if (listOf('=', '*', '/', '%', '-', '+', '<', '>').contains(sql[i])) {
-
-            //TODO add support for `>=`, `<=`, `<>`, and `!=`
-
+        } else if (listOf('=', '*', '/', '%', '-', '+', '<', '>', '!').contains(sql[i])) {
+            val start = i
             i++
-            return OperatorToken(sql[i-1].toString())
+
+            if (listOf('<').contains(sql[start]) && listOf('>').contains(sql[i])) {
+                // Confirm compound operator: `<>`
+                i++
+            } else if (listOf('>', '<', '!').contains(sql[start]) && '=' == sql[i]) {
+                // Confirm compound operators: `>=`, `<=`, and `!=`
+                i++
+            }
+
+            if (sql[start] == '!' && start == i - 1) {
+                throw IllegalStateException("Invalid character '${sql[start]}' at position $start in '$sql' expected: !=")
+            }
+
+            val str = sql.substring(start, i)
+            return OperatorToken(str)
 
         } else if (sql[i] == '\'') {
             //TODO handle escaped quotes in string

--- a/jvm/sql/src/test/kotlin/SqlTokenizerTest.kt
+++ b/jvm/sql/src/test/kotlin/SqlTokenizerTest.kt
@@ -72,7 +72,6 @@ class SqlTokenizerTest {
         assertEquals(expected, actual)
     }
 
-
     @Test
     fun `tokenize SELECT with aggregates`() {
         val expected = listOf(
@@ -115,7 +114,6 @@ class SqlTokenizerTest {
         val actual = tokenize("a >= b OR a <= b OR a <> b OR a != b")
         assertEquals(expected, actual)
     }
-
 
     @Test
     fun `tokenize long values`() {

--- a/jvm/sql/src/test/kotlin/SqlTokenizerTest.kt
+++ b/jvm/sql/src/test/kotlin/SqlTokenizerTest.kt
@@ -1,5 +1,6 @@
 package org.ballistacompute.sql
 
+import org.ballistacompute.logical.LiteralString
 import org.junit.Test
 import org.junit.jupiter.api.TestInstance
 import kotlin.test.assertEquals
@@ -11,13 +12,45 @@ class SqlTokenizerTest {
     fun `tokenize simple SELECT`() {
         val expected = listOf(
                 KeywordToken("SELECT"),
-                IdentifierToken("a"),
+                IdentifierToken("id"),
                 CommaToken(),
-                IdentifierToken("b"),
+                IdentifierToken("first_name"),
+                CommaToken(),
+                IdentifierToken("last_name"),
                 KeywordToken("FROM"),
                 IdentifierToken("employee")
         )
-        val actual = tokenize("SELECT a, b FROM employee")
+        val actual = tokenize("SELECT id, first_name, last_name FROM employee")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `projection with binary expression`() {
+        val expected = listOf(
+                KeywordToken("SELECT"),
+                IdentifierToken("salary"),
+                OperatorToken("*"),
+                LiteralDoubleToken("0.1"),
+                KeywordToken("FROM"),
+                IdentifierToken("employee")
+        )
+        val actual = tokenize("SELECT salary * 0.1 FROM employee")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `projection with aliased binary expression`() {
+        val expected = listOf(
+                KeywordToken("SELECT"),
+                IdentifierToken("salary"),
+                OperatorToken("*"),
+                LiteralDoubleToken("0.1"),
+                KeywordToken("AS"),
+                IdentifierToken("bonus"),
+                KeywordToken("FROM"),
+                IdentifierToken("employee")
+        )
+        val actual = tokenize("SELECT salary * 0.1 AS bonus FROM employee")
         assertEquals(expected, actual)
     }
 
@@ -36,6 +69,73 @@ class SqlTokenizerTest {
                 LiteralStringToken("CO")
         )
         val actual = tokenize("SELECT a, b FROM employee WHERE state = 'CO'")
+        assertEquals(expected, actual)
+    }
+
+
+    @Test
+    fun `tokenize SELECT with aggregates`() {
+        val expected = listOf(
+                KeywordToken("SELECT"),
+                IdentifierToken("state"),
+                CommaToken(),
+                IdentifierToken("MAX"),
+                LParenToken(),
+                IdentifierToken("salary"),
+                RParenToken(),
+                KeywordToken("FROM"),
+                IdentifierToken("employee"),
+                KeywordToken("GROUP"),
+                KeywordToken("BY"),
+                IdentifierToken("state")
+        )
+        val actual = tokenize("SELECT state, MAX(salary) FROM employee GROUP BY state")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `tokenize compound operators`() {
+        val expected = listOf(
+                IdentifierToken("a"),
+                OperatorToken(">="),
+                IdentifierToken("b"),
+                KeywordToken("OR"),
+                IdentifierToken("a"),
+                OperatorToken("<="),
+                IdentifierToken("b"),
+                KeywordToken("OR"),
+                IdentifierToken("a"),
+                OperatorToken("<>"),
+                IdentifierToken("b"),
+                KeywordToken("OR"),
+                IdentifierToken("a"),
+                OperatorToken("!="),
+                IdentifierToken("b")
+        )
+        val actual = tokenize("a >= b OR a <= b OR a <> b OR a != b")
+        assertEquals(expected, actual)
+    }
+
+
+    @Test
+    fun `tokenize long values`() {
+        val expected = listOf(
+                LiteralLongToken("123456789"),
+                OperatorToken("+"),
+                LiteralLongToken("987654321")
+        )
+        val actual = tokenize("123456789 + 987654321")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `tokenize float double values`() {
+        val expected = listOf(
+                LiteralDoubleToken("123456789.00"),
+                OperatorToken("+"),
+                LiteralDoubleToken("987654321.001")
+        )
+        val actual = tokenize("123456789.00 + 987654321.001")
         assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
### Changes
- Expands SQLTokenizer tests by mirroring many of the tests from the SQLParer.
- Add basic tests for LiteralDoubleToken, LiteralLongToken.
- Add support for compound operators.
- Add test for compound operators.

There's more changes I'd like to make to the tokenizer to make it more robust, but thought this would be a good way to get introduced into the project.

My only question at the moment is: Is there a particular SQL implementation the Tokenizer should aim to support?