### PR TITLE
Various benchmarking and packaging improvements

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.2.4"
+version = "0.2.5-SNAPSHOT"
 dependencies = [
  "clap",
 ]

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     let path = matches.value_of("path").unwrap();
     let cpus = matches.value_of("cpus").unwrap().parse::<usize>().unwrap();
 
-    let version = "0.2.4";
+    let version = "0.2.5-SNAPSHOT";
 
     match bench {
         "spark" => {

--- a/dev/build-rust.sh
+++ b/dev/build-rust.sh
@@ -7,5 +7,10 @@ cargo fmt
 cargo test
 popd
 
+pushd rust/becnhmarks
+cargo fmt
+cargo test
+popd
+
 docker build -t ballistacompute/ballista-rust:0.2.5-SNAPSHOT -f docker/rust-executor.dockerfile .
 docker build -t ballistacompute/rust-benchmarks:0.2.5-SNAPSHOT -f docker/rust-benchmarks.dockerfile .

--- a/docker/jvm-benchmarks.dockerfile
+++ b/docker/jvm-benchmarks.dockerfile
@@ -4,4 +4,6 @@ ADD build/distributions/benchmarks.tar /opt
 
 EXPOSE 50051
 
+ENV JAVA_OPTS="-Xms4g -Xmx8g"
+
 CMD ["/opt/benchmarks/bin/benchmarks"]

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -1,3 +1,4 @@
+# Base image extends debian:buster-slim
 FROM rustlang/rust:nightly AS build
 
 USER root

--- a/docker/rust-benchmarks.dockerfile
+++ b/docker/rust-benchmarks.dockerfile
@@ -1,3 +1,4 @@
+# Base image extends rust:nightly which extends debian:buster-slim
 FROM ballistacompute/rust-cached-deps:0.2.3 as build
 
 # Add Ballista

--- a/docker/rust-benchmarks.dockerfile
+++ b/docker/rust-benchmarks.dockerfile
@@ -17,26 +17,14 @@ COPY rust/benchmarks/Cargo.* /tmp/ballista/benchmarks/
 COPY rust/benchmarks/src/ /tmp/ballista/benchmarks/src/
 
 RUN cargo build --release
-ENTRYPOINT ["target/release/ballista-benchmarks"]
 
-#TODO the following makes the runtime extremely slow!
+# Copy the binary into a new container for a smaller docker image
+FROM debian:buster-slim
 
-# Build
-#RUN cargo build --release --target x86_64-unknown-linux-musl
+COPY --from=build /tmp/ballista/benchmarks/target/release/ballista-benchmarks /
+USER root
 
-# Copy the statically-linked binary into a scratch container.
-#FROM alpine:3.10
-#
-## Install Tini for better signal handling
-#RUN apk add --no-cache tini
-#ENTRYPOINT ["/sbin/tini", "--"]
-#
-#COPY --from=build /tmp/ballista/benchmarks/target/x86_64-unknown-linux-musl/release/ballista-benchmarks /
-#USER 1000
-#
-#EXPOSE 9090
-#
-#ENV RUST_LOG=info
-#ENV RUST_BACKTRACE=full
-#
-#CMD ["/ballista-benchmarks"]
+ENV RUST_LOG=info
+ENV RUST_BACKTRACE=full
+
+CMD ["/ballista-benchmarks"]

--- a/docker/rust-cached-deps.dockerfile
+++ b/docker/rust-cached-deps.dockerfile
@@ -1,3 +1,4 @@
+# Base image extends rust:nightly which extends debian:buster-slim
 FROM ballistacompute/rust-base as build
 
 # Fetch Ballista dependencies

--- a/docker/rust-executor.dockerfile
+++ b/docker/rust-executor.dockerfile
@@ -1,3 +1,4 @@
+# Base image extends rust:nightly which extends debian:buster-slim
 FROM ballistacompute/rust-cached-deps:0.2.3 as build
 
 # Compile Ballista

--- a/docker/rust-executor.dockerfile
+++ b/docker/rust-executor.dockerfile
@@ -11,25 +11,14 @@ COPY proto/ballista.proto /tmp/ballista/proto/
 COPY rust/format/Flight.proto /format
 
 RUN cargo build --release
-ENTRYPOINT ["target/release/executor"]
 
-#TODO the following makes the runtime extremely slow!
+# Copy the binary into a new container for a smaller docker image
+FROM debian:buster-slim
 
-#RUN cargo build --release --target x86_64-unknown-linux-musl
-#
-### Copy the statically-linked binary into a scratch container.
-#FROM alpine:3.10
-#
-## Install Tini for better signal handling
-#RUN apk add --no-cache tini
-#ENTRYPOINT ["/sbin/tini", "--"]
-#
-#COPY --from=build /tmp/ballista/target/x86_64-unknown-linux-musl/release/executor /
-#USER 1000
-#
-#EXPOSE 9090
-#
-#ENV RUST_LOG=info
-#ENV RUST_BACKTRACE=1
-#
-#CMD ["/executor"]
+COPY --from=build /tmp/ballista/target/release/executor /
+USER root
+
+ENV RUST_LOG=info
+ENV RUST_BACKTRACE=full
+
+CMD ["/executor"]

--- a/integration-tests/rust/Cargo.lock
+++ b/integration-tests/rust/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "0.2.4"
+version = "0.2.5-SNAPSHOT"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-integration-tests"
-version = "0.1.0"
+version = "0.2.5-SNAPSHOT"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/integration-tests/rust/src/main.rs
+++ b/integration-tests/rust/src/main.rs
@@ -4,7 +4,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 
 extern crate ballista;
 
-use ballista::dataframe::{max, min, Context};
+use ballista::dataframe::{max, min, Context, CSV_BATCH_SIZE};
 use ballista::error::Result;
 use ballista::logicalplan::*;
 use ballista::BALLISTA_VERSION;
@@ -32,7 +32,9 @@ async fn main() -> Result<()> {
             name, host, port
         );
         let start = Instant::now();
-        let ctx = Context::remote(host, *port);
+        let mut settings = HashMap::new();
+        settings.insert(CSV_BATCH_SIZE, "1024");
+        let ctx = Context::remote(host, *port, settings);
         let response = ctx
             .read_csv(filename, Some(nyctaxi_schema()), None, true)?
             .aggregate(

--- a/jvm/examples/src/main/kotlin/NYCTaxi.kt
+++ b/jvm/examples/src/main/kotlin/NYCTaxi.kt
@@ -16,8 +16,7 @@ import kotlin.system.measureTimeMillis
 
 fun main() {
 
-    val batchSize = 64 * 1024
-    val ctx = ExecutionContext(batchSize)
+    val ctx = ExecutionContext(mapOf())
 
     // wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv
 

--- a/jvm/examples/src/main/kotlin/ParallelQuery.kt
+++ b/jvm/examples/src/main/kotlin/ParallelQuery.kt
@@ -41,7 +41,7 @@ fun main() {
             "FROM tripdata " +
             "GROUP BY passenger_count"
 
-    val ctx = ExecutionContext()
+    val ctx = ExecutionContext(mapOf())
     ctx.registerDataSource("tripdata", InMemoryDataSource(results.first().schema, results))
     val df = ctx.sql(sql)
     ctx.execute(df).forEach { println(it) }
@@ -51,7 +51,7 @@ fun main() {
 fun executeQuery(path: String, month: Int, sql: String): List<RecordBatch> {
     val monthStr = String.format("%02d", month);
     val filename = "$path/yellow_tripdata_2019-$monthStr.csv"
-    val ctx = ExecutionContext()
+    val ctx = ExecutionContext(mapOf())
     ctx.registerCsv("tripdata", filename)
     val df = ctx.sql(sql)
     return ctx.execute(df).toList()

--- a/jvm/execution/src/main/kotlin/ExecutionContext.kt
+++ b/jvm/execution/src/main/kotlin/ExecutionContext.kt
@@ -12,7 +12,9 @@ import org.ballistacompute.sql.SqlSelect
 import org.ballistacompute.sql.SqlTokenizer
 
 /** Execution context */
-class ExecutionContext(val batchSize: Int = 1024 * 1024) {
+class ExecutionContext(val settings: Map<String,String>) {
+
+    val batchSize: Int = settings.getOrDefault("ballista.csv.batchSize", "1024").toInt()
 
     /** Tables registered with this context */
     private val tables = mutableMapOf<String, DataFrame>()

--- a/jvm/execution/src/test/kotlin/ExecutionSqlTest.kt
+++ b/jvm/execution/src/test/kotlin/ExecutionSqlTest.kt
@@ -73,7 +73,7 @@ class ExecutionSqlTest {
     }
 
     private fun createContext() : ExecutionContext {
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
         ctx.register("employee", ctx.csv(employeeCsv))
         return ctx
     }

--- a/jvm/execution/src/test/kotlin/ExecutionTest.kt
+++ b/jvm/execution/src/test/kotlin/ExecutionTest.kt
@@ -22,7 +22,7 @@ class ExecutionTest {
     @Test
     fun `employees in CO using DataFrame`() {
         // Create a context
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
 
         // Construct a query using the DataFrame API
         val df = ctx.csv(employeeCsv)
@@ -41,7 +41,7 @@ class ExecutionTest {
     @Test
     fun `employees in CA using SQL`() {
         // Create a context
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
 
         val employee = ctx.csv(employeeCsv)
         ctx.register("employee", employee)
@@ -60,7 +60,7 @@ class ExecutionTest {
     @Test
     fun `aggregate query`() {
         // Create a context
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
 
         // construct a query using the DataFrame API
         val df = ctx.csv(employeeCsv)
@@ -80,7 +80,7 @@ class ExecutionTest {
     @Test
     fun `bonuses in CA using SQL and DataFrame`() {
         // Create a context
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
 
         // construct a query using the DataFrame API
         val caEmployees = ctx.csv(employeeCsv)
@@ -117,7 +117,7 @@ class ExecutionTest {
 
         val dataSource = InMemoryDataSource(schema, listOf(input))
 
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
         val logicalPlan = DataFrameImpl(Scan("", dataSource, listOf()))
                 .aggregate(listOf(col("a")),
                         listOf(
@@ -152,7 +152,7 @@ class ExecutionTest {
 
         val dataSource = InMemoryDataSource(schema, listOf(input))
 
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
         val logicalPlan = DataFrameImpl(Scan("", dataSource, listOf()))
                 .project(
                         listOf(
@@ -189,7 +189,7 @@ class ExecutionTest {
 
         val dataSource = InMemoryDataSource(schema, listOf(input))
 
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
         val logicalPlan = DataFrameImpl(Scan("", dataSource, listOf()))
                 .project(
                         listOf(

--- a/jvm/execution/src/test/kotlin/ReadmeExamplesTest.kt
+++ b/jvm/execution/src/test/kotlin/ReadmeExamplesTest.kt
@@ -18,7 +18,7 @@ class ReadmeExamplesTest {
     fun `SQL example`() {
 
         // Create a context
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
 
         // Register a CSV data source
         val csv = ctx.csv(employeeCsv)
@@ -40,7 +40,7 @@ class ReadmeExamplesTest {
     fun `DataFrame example`() {
 
         // Create a context
-        val ctx = ExecutionContext()
+        val ctx = ExecutionContext(mapOf())
 
         // Construct a query using the DataFrame API
         val df: DataFrame = ctx.csv(employeeCsv)

--- a/jvm/executor/src/main/kotlin/BallistaFlightProducer.kt
+++ b/jvm/executor/src/main/kotlin/BallistaFlightProducer.kt
@@ -42,15 +42,14 @@ class BallistaFlightProducer : FlightProducer {
             //val loader = VectorLoader(root)
             var counter = 0
             results.iterator().forEach { batch ->
+                root.clear()
 
                 val rowCount = batch.rowCount()
                 println("Received batch with $rowCount rows")
 
-                if (rowCount > batchSize) {
-                    batchSize = rowCount
-                    root.fieldVectors.forEach { it.setInitialCapacity(batchSize) }
-                    root.allocateNew()
-                }
+                batchSize = rowCount
+                root.fieldVectors.forEach { it.setInitialCapacity(batchSize) }
+                root.allocateNew()
 
                 (0 until schema.fields.size).forEach { columnIndex ->
 
@@ -140,6 +139,7 @@ class BallistaFlightProducer : FlightProducer {
                 counter++
             }
 
+            root.close()
             listener.completed()
         } catch (ex: Exception) {
             ex.printStackTrace()

--- a/jvm/executor/src/main/kotlin/BallistaFlightProducer.kt
+++ b/jvm/executor/src/main/kotlin/BallistaFlightProducer.kt
@@ -9,7 +9,6 @@ import java.lang.IllegalStateException
 
 class BallistaFlightProducer : FlightProducer {
 
-    val ctx = ExecutionContext()
 
     override fun getStream(context: FlightProducer.CallContext?, ticket: Ticket?, listener: FlightProducer.ServerStreamListener?) {
 
@@ -26,11 +25,16 @@ class BallistaFlightProducer : FlightProducer {
             val schema = logicalPlan.schema()
             println(schema)
 
+            //TODO get from protobuf request
+            val settings = mapOf<String, String>()
+
+            val ctx = ExecutionContext(settings)
+
             val results = ctx.execute(logicalPlan)
 
             val allocator = RootAllocator(Long.MAX_VALUE)
 
-            var batchSize = 2
+            var batchSize = 1024
 
             val root = VectorSchemaRoot.create(schema.toArrow(), allocator)
             listener.start(root, null)

--- a/rust/benchmarks/Cargo.lock
+++ b/rust/benchmarks/Cargo.lock
@@ -206,7 +206,6 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "ballista",
- "clap",
  "datafusion",
  "tokio 0.2.19",
 ]

--- a/rust/benchmarks/Cargo.lock
+++ b/rust/benchmarks/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "0.2.4"
+version = "0.2.5-SNAPSHOT"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-benchmarks"
-version = "0.2.4"
+version = "0.2.5-SNAPSHOT"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -9,5 +9,4 @@ ballista = { path=".." }
 arrow = "0.17"
 arrow-flight = "0.17"
 datafusion = "0.17"
-clap = "2.33"
 tokio = { version = "0.2", features = ["full"] }

--- a/rust/benchmarks/run-native.sh
+++ b/rust/benchmarks/run-native.sh
@@ -4,4 +4,7 @@ export BENCH_PATH=/mnt/nyctaxi/csv/year=2019
 export BENCH_RESULT_FILE=rust-debug.txt
 
 # run natively
-cargo run --release
+#cargo run --release
+
+cargo build --release --target x86_64-unknown-linux-musl
+target/x86_64-unknown-linux-musl/release/ballista-benchmarks

--- a/rust/benchmarks/src/main.rs
+++ b/rust/benchmarks/src/main.rs
@@ -19,6 +19,7 @@ use datafusion::utils;
 
 use tokio::task;
 use clap::{App, Arg};
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -60,7 +61,11 @@ async fn main() -> Result<()> {
 
 async fn local_mode_benchmark(path: &str, results_filename: &str) -> Result<()> {
     let start = Instant::now();
-    let ctx = Context::local();
+
+    let mut settings = HashMap::new();
+    settings.insert("ballista.csv.batchSize", "1000");
+
+    let ctx = Context::local(settings);
     let df = create_csv_query(&ctx, path)?;
     df.explain();
 
@@ -143,7 +148,9 @@ async fn k8s(path: &str) -> Result<()> {
     utils::print_batches(&batches)?;
 
     // perform secondary aggregate query on the results collected from the executors
-    let ctx = Context::local();
+    let mut settings = HashMap::new();
+
+    let ctx = Context::local(settings);
 
     let results = ctx
         .create_dataframe(&batches)?

--- a/rust/benchmarks/src/main.rs
+++ b/rust/benchmarks/src/main.rs
@@ -10,7 +10,7 @@ use arrow::record_batch::RecordBatch;
 extern crate ballista;
 
 use ballista::cluster;
-use ballista::dataframe::{min, max, sum, Context, DataFrame};
+use ballista::dataframe::{min, max, sum, Context, DataFrame, CSV_BATCH_SIZE};
 use ballista::error::{Result, BallistaError};
 use ballista::logicalplan::*;
 use ballista::BALLISTA_VERSION;
@@ -18,31 +18,12 @@ use ballista::BALLISTA_VERSION;
 use datafusion::utils;
 
 use tokio::task;
-use clap::{App, Arg};
 use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {
 
-    // let matches = App::new("Ballista Benchmark Client")
-    //     .version(BALLISTA_VERSION)
-    //     .arg(Arg::with_name("mode")
-    //         .short("m")
-    //         .long("mode")
-    //         .help("Benchmark mode: local or k8s")
-    //         .takes_value(true))
-    //     .arg(Arg::with_name("path")
-    //         .short("p")
-    //         .long("path")
-    //         .value_name("FILE")
-    //         .help("Path to data files")
-    //         .takes_value(true))
-    //     .get_matches();
-    //
-    //
-    //
-    // let mode = matches.value_of("mode").unwrap_or("");
-    // let path = matches.value_of("path").unwrap_or("").to_owned();
+    println!("Ballista Rust Benchmarks v{}", BALLISTA_VERSION);
 
     let mode = env::var("BENCH_MODE").unwrap();
     let path = env::var("BENCH_PATH").unwrap();
@@ -63,7 +44,7 @@ async fn local_mode_benchmark(path: &str, results_filename: &str) -> Result<()> 
     let start = Instant::now();
 
     let mut settings = HashMap::new();
-    settings.insert("ballista.csv.batchSize", "1000");
+    settings.insert(CSV_BATCH_SIZE, "1024");
 
     let ctx = Context::local(settings);
     let df = create_csv_query(&ctx, path)?;
@@ -149,6 +130,7 @@ async fn k8s(path: &str) -> Result<()> {
 
     // perform secondary aggregate query on the results collected from the executors
     let mut settings = HashMap::new();
+    settings.insert(CSV_BATCH_SIZE, "1024");
 
     let ctx = Context::local(settings);
 
@@ -170,7 +152,9 @@ async fn k8s(path: &str) -> Result<()> {
 async fn execute_remote(host: &str, port: usize, filename: &str) -> Result<Vec<RecordBatch>> {
     println!("Executing query against executor at {}:{}", host, port);
     let start = Instant::now();
-    let ctx = Context::remote(host, port);
+    let mut settings = HashMap::new();
+    settings.insert(CSV_BATCH_SIZE, "1024");
+    let ctx = Context::remote(host, port, settings);
     let df = create_csv_query(&ctx, filename)?;
     let response = df
         .collect()

--- a/rust/examples/parallel-aggregate/main.rs
+++ b/rust/examples/parallel-aggregate/main.rs
@@ -120,7 +120,7 @@ async fn execute_remote(host: &str, port: usize, filename: &str) -> Result<Vec<R
     println!("Executing query against executor at {}:{}", host, port);
     let start = Instant::now();
 
-    let ctx = Context::remote(host, port);
+    let ctx = Context::remote(host, port, HashMap::new());
 
     let response = ctx
         .read_csv(filename, Some(nyctaxi_schema()), None, true)?

--- a/rust/examples/parallel-aggregate/main.rs
+++ b/rust/examples/parallel-aggregate/main.rs
@@ -15,6 +15,7 @@ use ballista::BALLISTA_VERSION;
 
 use datafusion::utils;
 
+use std::collections::HashMap;
 use tokio::task;
 
 #[tokio::main]
@@ -98,7 +99,7 @@ async fn main() -> Result<()> {
     println!("Received {} batches from executors", batches.len());
 
     // perform secondary aggregate query on the results collected from the executors
-    let ctx = Context::local();
+    let ctx = Context::local(HashMap::new());
 
     let results = ctx
         .create_dataframe(&batches)?

--- a/rust/examples/parallel-aggregate/parallel-aggregate-rs.yaml
+++ b/rust/examples/parallel-aggregate/parallel-aggregate-rs.yaml
@@ -8,7 +8,5 @@ spec:
       containers:
         - name: parallel-aggregate
           image: ballistacompute/parallel-aggregate-rs
-          # because we're testing in Minikube, we never want to pull remote images
-          imagePullPolicy: Never
       restartPolicy: Never
   backoffLimit: 4

--- a/rust/src/dataframe.rs
+++ b/rust/src/dataframe.rs
@@ -13,6 +13,9 @@ use std::sync::Arc;
 use crate::plan::Action;
 use datafusion::datasource::MemTable;
 
+pub const CSV_BATCH_SIZE: &'static str = "ballista.csv.batchSize";
+
+/// Configuration setting
 struct ConfigSetting {
     key: String,
     description: String,
@@ -41,9 +44,9 @@ struct Configs {
 impl Configs {
     pub fn new(settings: HashMap<String, String>) -> Self {
         let csv_batch_size: ConfigSetting = ConfigSetting::new(
-            "ballista.csv.batchSize",
+            CSV_BATCH_SIZE,
             "Number of rows to read per batch",
-            Some("10000"),
+            Some("1024"),
         );
 
         let configs = vec![csv_batch_size];
@@ -70,7 +73,7 @@ impl Configs {
     }
 
     pub fn csv_batch_size(&self) -> Option<String> {
-        self.get_setting("ballista.csv.batchSize")
+        self.get_setting(CSV_BATCH_SIZE)
     }
 }
 
@@ -86,8 +89,7 @@ pub enum ContextState {
     Remote {
         host: String,
         port: usize,
-        //TODO
-        //settings: HashMap<String, String>,
+        settings: HashMap<String, String>,
     },
     Spark {
         master: String,
@@ -98,35 +100,30 @@ pub enum ContextState {
 impl Context {
     /// Create a context for executing a query against a remote Spark executor
     pub fn spark(master: &str, settings: HashMap<&str, &str>) -> Self {
-        let mut s: HashMap<String, String> = HashMap::new();
-        for (k, v) in settings {
-            s.insert(k.to_owned(), v.to_owned());
-        }
         Self {
             state: Arc::new(ContextState::Spark {
                 master: master.to_owned(),
-                spark_settings: s,
+                spark_settings: parse_settings(settings),
             }),
         }
     }
 
     /// Create a context for executing a query against a local in-process executor
     pub fn local(settings: HashMap<&str, &str>) -> Self {
-        let mut s: HashMap<String, String> = HashMap::new();
-        for (k, v) in settings {
-            s.insert(k.to_owned(), v.to_owned());
-        }
         Self {
-            state: Arc::new(ContextState::Local { settings: s }),
+            state: Arc::new(ContextState::Local {
+                settings: parse_settings(settings),
+            }),
         }
     }
 
     /// Create a context for executing a query against a remote executor
-    pub fn remote(host: &str, port: usize) -> Self {
+    pub fn remote(host: &str, port: usize, settings: HashMap<&str, &str>) -> Self {
         Self {
             state: Arc::new(ContextState::Remote {
                 host: host.to_owned(),
                 port,
+                settings: parse_settings(settings),
             }),
         }
     }
@@ -170,6 +167,13 @@ impl Context {
     }
 }
 
+fn parse_settings(settings: HashMap<&str, &str>) -> HashMap<String, String> {
+    let mut s: HashMap<String, String> = HashMap::new();
+    for (k, v) in settings {
+        s.insert(k.to_owned(), v.to_owned());
+    }
+    s
+}
 /// Builder for logical plans
 pub struct DataFrame {
     ctx_state: Arc<ContextState>,
@@ -306,7 +310,9 @@ impl DataFrame {
                 ctx.execute_action(host, port.parse::<usize>().unwrap(), action)
                     .await
             }
-            ContextState::Remote { host, port } => ctx.execute_action(host, *port, action).await,
+            ContextState::Remote { host, port, .. } => {
+                ctx.execute_action(host, *port, action).await
+            }
             ContextState::Local { settings } => {
                 // create local execution context
                 let mut ctx = datafusion::execution::context::ExecutionContext::new();
@@ -547,5 +553,19 @@ fn translate_scalar_value(value: &ScalarValue) -> Result<datafusion::logicalplan
             "Cannot translate scalar value to DataFusion: {:?}",
             other
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_context_ux() {
+        let mut settings = HashMap::new();
+        settings.insert(CSV_BATCH_SIZE, "2048");
+        settings.insert("custom.setting", "/foo/bar");
+
+        let ctx = Context::local(settings);
     }
 }

--- a/rust/src/dataframe.rs
+++ b/rust/src/dataframe.rs
@@ -13,16 +13,81 @@ use std::sync::Arc;
 use crate::plan::Action;
 use datafusion::datasource::MemTable;
 
+struct ConfigSetting {
+    key: String,
+    description: String,
+    default_value: Option<String>,
+}
+
+impl ConfigSetting {
+    pub fn new(key: &str, description: &str, default_value: Option<&str>) -> Self {
+        Self {
+            key: key.to_owned(),
+            description: description.to_owned(),
+            default_value: default_value.map(|s| s.to_owned()),
+        }
+    }
+
+    pub fn default_value(&self) -> Option<String> {
+        self.default_value.clone()
+    }
+}
+
+struct Configs {
+    configs: HashMap<String, ConfigSetting>,
+    settings: HashMap<String, String>,
+}
+
+impl Configs {
+    pub fn new(settings: HashMap<String, String>) -> Self {
+        let csv_batch_size: ConfigSetting = ConfigSetting::new(
+            "ballista.csv.batchSize",
+            "Number of rows to read per batch",
+            Some("10000"),
+        );
+
+        let configs = vec![csv_batch_size];
+
+        let mut m = HashMap::new();
+        for config in configs {
+            m.insert(config.key.clone(), config);
+        }
+
+        Self {
+            configs: m,
+            settings,
+        }
+    }
+
+    pub fn get_setting(&self, name: &str) -> Option<String> {
+        match self.settings.get(name) {
+            Some(value) => Some(value.clone()),
+            None => match self.configs.get(name) {
+                Some(value) => value.default_value(),
+                None => None,
+            },
+        }
+    }
+
+    pub fn csv_batch_size(&self) -> Option<String> {
+        self.get_setting("ballista.csv.batchSize")
+    }
+}
+
 pub struct Context {
     state: Arc<ContextState>,
 }
 
 #[derive(Debug, Clone)]
 pub enum ContextState {
-    Local,
+    Local {
+        settings: HashMap<String, String>,
+    },
     Remote {
         host: String,
         port: usize,
+        //TODO
+        //settings: HashMap<String, String>,
     },
     Spark {
         master: String,
@@ -46,9 +111,13 @@ impl Context {
     }
 
     /// Create a context for executing a query against a local in-process executor
-    pub fn local() -> Self {
+    pub fn local(settings: HashMap<&str, &str>) -> Self {
+        let mut s: HashMap<String, String> = HashMap::new();
+        for (k, v) in settings {
+            s.insert(k.to_owned(), v.to_owned());
+        }
         Self {
-            state: Arc::new(ContextState::Local),
+            state: Arc::new(ContextState::Local { settings: s }),
         }
     }
 
@@ -238,7 +307,7 @@ impl DataFrame {
                     .await
             }
             ContextState::Remote { host, port } => ctx.execute_action(host, *port, action).await,
-            ContextState::Local => {
+            ContextState::Local { settings } => {
                 // create local execution context
                 let mut ctx = datafusion::execution::context::ExecutionContext::new();
 
@@ -249,7 +318,13 @@ impl DataFrame {
 
                 println!("Optimized Plan: {:?}", optimized_plan);
 
-                let physical_plan = ctx.create_physical_plan(&optimized_plan, 1024 * 1024)?;
+                let x = Configs::new(settings.clone());
+
+                let batch_size = x.csv_batch_size().unwrap().parse::<usize>().unwrap();
+
+                println!("batch_size={}", batch_size);
+
+                let physical_plan = ctx.create_physical_plan(&optimized_plan, batch_size)?;
 
                 // execute the query
                 ctx.collect(physical_plan.as_ref())

--- a/spark/benchmarks/src/main/scala/org/ballistacompute/spark/benchmarks/Benchmarks.scala
+++ b/spark/benchmarks/src/main/scala/org/ballistacompute/spark/benchmarks/Benchmarks.scala
@@ -3,6 +3,7 @@ package org.ballistacompute.spark.benchmarks
 import java.io.{File, FileWriter}
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 
 object Benchmarks {


### PR DESCRIPTION
- Rust docker images now use debian:buster-slim and images are 89 MB
- CSV batch size is configurable
- Fixed bug in JVM flight producer