### PR TITLE
Workflow improvement for GitHub Workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,9 @@ on: [push]
 #  pull_request:
 #    branches: [ master ]
 
+env:
+  VCPKGRS_DYNAMIC: 1
+
 jobs:
   Ubuntu:
     runs-on: ubuntu-latest
@@ -45,19 +48,15 @@ jobs:
     - name: Install vcpkg
       run: |
         cd vcpkg && ./bootstrap-vcpkg.bat
-        vcpkg install openssl-windows:x64-windows
-        vcpkg install openssl:x64-windows-static
         vcpkg integrate install
-        set VCPKGRS_DYNAMIC=1
+        vcpkg install openssl:x64-windows
     - name: Setup
       run: |
         rustup default nightly-2020-05-14 && rustup component add rustfmt
     - name: Build
       run: |
-        set VCPKGRS_DYNAMIC=1
         cd rust && cargo build
     - name: Run tests
       run: |
-        set VCPKGRS_DYNAMIC=1
         cd rust && cargo test
     

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run tests
       run: cd rust && cargo test
 
-  Mac_OSX:
+  Mac:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,10 @@
 name: Rust
 
-on: [push]
-
-#on:
-#  push:
-#    branches: [ master ]
-#  pull_request:
-#    branches: [ master ]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 env:
   VCPKGRS_DYNAMIC: 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,10 +37,27 @@ jobs:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v2
+    - name: Pre-requisite for Windows vcpkg
+      uses: actions/checkout@v2
+      with:
+        repository: Microsoft/vcpkg
+        path: vcpkg
+    - name: Install vcpkg
+      run: |
+        cd vcpkg && ./bootstrap-vcpkg.bat
+        vcpkg install openssl-windows:x64-windows
+        vcpkg install openssl:x64-windows-static
+        vcpkg integrate install
+        set VCPKGRS_DYNAMIC=1
     - name: Setup
-      run: rustup default nightly-2020-05-14 && rustup component add rustfmt
+      run: |
+        rustup default nightly-2020-05-14 && rustup component add rustfmt
     - name: Build
-      run: cd rust && cargo build
+      run: |
+        set VCPKGRS_DYNAMIC=1
+        cd rust && cargo build
     - name: Run tests
-      run: cd rust && cargo test
+      run: |
+        set VCPKGRS_DYNAMIC=1
+        cd rust && cargo test
     

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,10 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  Ubuntu:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup
@@ -19,3 +17,28 @@ jobs:
       run: cd rust && cargo build
     - name: Run tests
       run: cd rust && cargo test
+
+  Mac_OSX:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup
+      run: |
+        brew install rustup
+        rustup default nightly-2020-05-14 && rustup component add rustfmt
+    - name: Build
+      run: cd rust && cargo build
+    - name: Run tests
+      run: cd rust && cargo test
+
+  Windows:
+    runs-on: windows-2016
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup
+      run: rustup default nightly-2020-05-14 && rustup component add rustfmt
+    - name: Build
+      run: cd rust && cargo build
+    - name: Run tests
+      run: cd rust && cargo test
+    

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,12 @@
 name: Rust
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push]
+
+#on:
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
 
 jobs:
   Ubuntu:


### PR DESCRIPTION
This fixes up the build so that it builds for three platforms: Linux Ubuntu, Mac OS X, and Windows.  Windows was a little bit of a red-headed step-child since it requires the use of `vcpkg` to install the openssl library.  This increases the build time by about 2.5x, unfortunately.