### PR TITLE
Issue 159: Windows builds failing with vcpkg error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,17 +49,21 @@ jobs:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v2
-    - name: Pre-requisite for Windows vcpkg
-      uses: actions/checkout@v2
-      with:
-        repository: Microsoft/vcpkg
-        path: vcpkg
-    - name: Install vcpkg
+    - name: Set up the Windows environment
       run: |
-        cd vcpkg && ./bootstrap-vcpkg.bat
-        vcpkg update
         vcpkg integrate install
         vcpkg install openssl:x64-windows
+#    - name: Pre-requisite for Windows vcpkg
+#      uses: actions/checkout@v2
+#      with:
+#        repository: Microsoft/vcpkg
+#        path: vcpkg
+#    - name: Install vcpkg
+#      run: |
+#        cd vcpkg && ./bootstrap-vcpkg.bat
+#        vcpkg update
+#        vcpkg integrate install
+#        vcpkg install openssl:x64-windows
     - name: Setup
       run: |
         rustup default ${RUSTUP_VERSION} && rustup component add rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,13 +1,16 @@
 name: Rust
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+#on:
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
+
+on: [push]
 
 env:
   VCPKGRS_DYNAMIC: 1
+  RUSTUP_VERSION: nightly-2020-05-14
 
 jobs:
   Ubuntu:
@@ -15,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup
-      run: rustup default nightly-2020-05-14 && rustup component add rustfmt
+      run: rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
     - name: Build
       run: cd rust && cargo build
     - name: Build IT
@@ -32,7 +35,7 @@ jobs:
     - name: Setup
       run: |
         brew install rustup
-        rustup default nightly-2020-05-14 && rustup component add rustfmt
+        rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
     - name: Build
       run: cd rust && cargo build
     - name: Build IT
@@ -54,11 +57,12 @@ jobs:
     - name: Install vcpkg
       run: |
         cd vcpkg && ./bootstrap-vcpkg.bat
+        vcpkg update
         vcpkg integrate install
         vcpkg install openssl:x64-windows
     - name: Setup
       run: |
-        rustup default nightly-2020-05-14 && rustup component add rustfmt
+        rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
     - name: Build
       run: |
         cd rust && cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,16 +1,18 @@
 name: Rust
 
-#on:
-#  push:
-#    branches: [ master ]
-#  pull_request:
-#    branches: [ master ]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
-on: [push]
+# Note, toolchain version must match the rustup version: either "nightly" or "nightly-YYYY-MM-DD"
+# and must contain the toolchain for the OS at the end.
 
 env:
   VCPKGRS_DYNAMIC: 1
   RUSTUP_VERSION: nightly-2020-05-14
+  TOOLCHAIN_VERSION: nightly-2020-05-14-x86_64-pc-windows-msvc
 
 jobs:
   Ubuntu:
@@ -19,9 +21,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup
       run: rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
-    - name: Build
+    - name: Build Ballista
       run: cd rust && cargo build
-    - name: Build IT
+    - name: Build Integration Tests
       run: cd integration-tests/rust && cargo build
     - name: Build Benchmarks
       run: cd benchmarks && cargo build
@@ -36,9 +38,9 @@ jobs:
       run: |
         brew install rustup
         rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
-    - name: Build
+    - name: Build Ballista
       run: cd rust && cargo build
-    - name: Build IT
+    - name: Build Integration Tests
       run: cd integration-tests/rust && cargo build
     - name: Build Benchmarks
       run: cd benchmarks && cargo build
@@ -49,20 +51,20 @@ jobs:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v2
-    - name: Set up the Windows environment
+    - name: Prepare the Windows Build Environment
       run: |
         vcpkg update
         vcpkg integrate install
         vcpkg install openssl:x64-windows
-    - name: Setup
+    - name: Setup Rust Nightly
       run: |
         rustup default ${RUSTUP_VERSION}
-        rustup toolchain install nightly-2020-05-14
-        rustup component add rustfmt --toolchain nightly-2020-05-14-x86_64-pc-windows-msvc
-    - name: Build
+        rustup toolchain install ${RUSTUP_VERSION}
+        rustup component add rustfmt --toolchain ${TOOLCHAIN_VERSION}
+    - name: Build Ballista
       run: |
         cd rust && cargo build
-    - name: Build IT
+    - name: Build Integration Tests
       run: |
         cd integration-tests/rust && cargo build
     - name: Build Becnhmarks

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Setup
       run: |
         rustup default ${RUSTUP_VERSION}
-        rustup component add rustfmt --toolchain ${RUSTUP_VERSION}-x86_64-pc-windows-msvc
+        rustup component add rustfmt --toolchain nightly-2020-05-14-x86_64-pc-windows-msvc
     - name: Build
       run: |
         cd rust && cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,9 +58,9 @@ jobs:
         vcpkg install openssl:x64-windows
     - name: Setup Rust Nightly
       run: |
-        rustup default ${RUSTUP_VERSION}
-        rustup toolchain install ${RUSTUP_VERSION}
-        rustup component add rustfmt --toolchain ${TOOLCHAIN_VERSION}
+        rustup default $RUSTUP_VERSION
+        rustup toolchain install $RUSTUP_VERSION
+        rustup component add rustfmt --toolchain $TOOLCHAIN_VERSION
     - name: Build Ballista
       run: |
         cd rust && cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Setup
       run: |
         rustup default ${RUSTUP_VERSION}
+        rustup toolchain install nightly-2020-05-14
         rustup component add rustfmt --toolchain nightly-2020-05-14-x86_64-pc-windows-msvc
     - name: Build
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,19 +51,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up the Windows environment
       run: |
+        vcpkg update
         vcpkg integrate install
         vcpkg install openssl:x64-windows
-#    - name: Pre-requisite for Windows vcpkg
-#      uses: actions/checkout@v2
-#      with:
-#        repository: Microsoft/vcpkg
-#        path: vcpkg
-#    - name: Install vcpkg
-#      run: |
-#        cd vcpkg && ./bootstrap-vcpkg.bat
-#        vcpkg update
-#        vcpkg integrate install
-#        vcpkg install openssl:x64-windows
     - name: Setup
       run: |
         rustup default ${RUSTUP_VERSION} && rustup component add rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,9 +58,9 @@ jobs:
         vcpkg install openssl:x64-windows
     - name: Setup Rust Nightly
       run: |
-        rustup default $RUSTUP_VERSION
-        rustup toolchain install $RUSTUP_VERSION
-        rustup component add rustfmt --toolchain $TOOLCHAIN_VERSION
+        rustup default nightly-2020-05-14
+        rustup toolchain install nightly-2020-05-14
+        rustup component add rustfmt --toolchain nightly-2020-05-14-x86_64-pc-windows-msvc
     - name: Build Ballista
       run: |
         cd rust && cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,8 @@ jobs:
         vcpkg install openssl:x64-windows
     - name: Setup
       run: |
-        rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
+        rustup default ${RUSTUP_VERSION}
+        rustup component add rustfmt --toolchain ${RUSTUP_VERSION}-x86_64-pc-windows-msvc
     - name: Build
       run: |
         cd rust && cargo build


### PR DESCRIPTION
The build was a little more complicated than I expected.  While it was suggested that vcpkg be cloned and installed, turns out, GitHub already has the tools pre-installed.  This new update takes advantage of this, updating the library for the build, and addressing an issue with `rustfmt` on Windows.  It also tweaks the names of each build step so that it is more clear in the Actions page as to what is happening.