### PR TITLE
Added build name and version to manifest, printed name and versi…

### DIFF
--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Instant
+
 plugins {
     java
     `java-library`
@@ -17,8 +19,8 @@ allprojects {
         mavenCentral()
         jcenter()
     }
-
 }
+
 subprojects {
     apply {
         plugin("org.jetbrains.kotlin.jvm")
@@ -60,6 +62,16 @@ subprojects {
     tasks.dokka {
         outputFormat = "html"
         outputDirectory = "$buildDir/javadoc"
+    }
+
+    tasks.jar {
+        manifest {
+            attributes(
+                "Implementation-Title" to "${rootProject.name}-${archiveBaseName.get()}",
+                "Implementation-Version" to rootProject.version,
+                "Build-Timestamp" to Instant.now()
+            )
+        }
     }
 
     val sourcesJar = tasks.create<Jar>("sourcesJar") {

--- a/jvm/executor/src/main/kotlin/Executor.kt
+++ b/jvm/executor/src/main/kotlin/Executor.kt
@@ -22,6 +22,9 @@ class Executor {
     companion object {
         @JvmStatic
         fun main(args: Array<String>) {
+            val name = Executor::class.java.`package`.implementationTitle
+            val version = Executor::class.java.`package`.implementationVersion
+            println("Starting $name $version")
 
             // https://issues.apache.org/jira/browse/ARROW-5412
             System.setProperty( "io.netty.tryReflectionSetAccessible","true")

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Instant
+
 plugins {
     scala
     kotlin("jvm") version "1.3.50" apply false
@@ -45,6 +47,16 @@ subprojects {
 
         testImplementation("junit:junit:4.12")
 
+    }
+
+    tasks.jar {
+        manifest {
+            attributes(
+                "Implementation-Title" to "${rootProject.name}-${archiveBaseName.get()}",
+                "Implementation-Version" to rootProject.version,
+                "Build-Timestamp" to Instant.now()
+            )
+        }
     }
 }
 

--- a/spark/executor/src/main/scala/org/ballistacompute/spark/executor/SparkExecutor.scala
+++ b/spark/executor/src/main/scala/org/ballistacompute/spark/executor/SparkExecutor.scala
@@ -21,6 +21,9 @@ import org.apache.spark.sql.SparkSession
 object SparkExecutor {
 
   def main(arg: Array[String]): Unit = {
+    val name = SparkExecutor.getClass.getPackage.getImplementationTitle
+    val version = SparkExecutor.getClass.getPackage.getImplementationVersion
+    println(s"Starting $name $version")
 
     //TODO command-line params
     val master = "local[1]" // single-threaded for benchmarks against Rust/JVM executors


### PR DESCRIPTION
After trying to add the version to all sub-projects and facing conflicts as discussed [here](https://github.com/ballista-compute/ballista/issues/129#issuecomment-647185358), I decided to go with the simpler version of change, which is to write the manifest using the parent project's version number.

**Spark Executor logs**
```
Starting ballista-spark-executor 0.3.0-SNAPSHOT
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
20/06/26 23:04:15 INFO SparkContext: Running Spark version 3.0.0-preview2
20/06/26 23:04:15 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
```

**JVM Executor logs**
```
Starting ballista-jvm-executor 0.3.0-SNAPSHOT
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/executor/lib/gradle-api-6.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/executor/lib/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
```