### PR TITLE
[Rust] Create data structures for physical plan

### DIFF
--- a/rust/ballista/src/bin/executor.rs
+++ b/rust/ballista/src/bin/executor.rs
@@ -20,7 +20,7 @@ use ballista::arrow::ipc;
 use ballista::datafusion::execution::context::ExecutionContext;
 use ballista::serde::decode_protobuf;
 
-use ballista::{plan, BALLISTA_VERSION};
+use ballista::{physical_plan, BALLISTA_VERSION};
 
 use arrow::record_batch::RecordBatch;
 use ballista::scheduler::create_job;
@@ -122,7 +122,7 @@ impl FlightService for FlightServiceImpl {
         let action = decode_protobuf(&request.cmd.to_vec()).map_err(|e| to_tonic_err(&e))?;
 
         match &action {
-            plan::Action::Collect { plan: logical_plan } => {
+            physical_plan::Action::Collect { plan: logical_plan } => {
                 println!("Logical plan: {:?}", logical_plan);
 
                 let job = create_job(logical_plan).map_err(|e| to_tonic_err(&e))?;
@@ -240,9 +240,9 @@ fn schema_to_bytes(schema: &Schema) -> Vec<u8> {
     data.to_vec()
 }
 
-fn execute_action(action: &plan::Action) -> Result<Results, Status> {
+fn execute_action(action: &physical_plan::Action) -> Result<Results, Status> {
     match &action {
-        plan::Action::Collect { plan: logical_plan } => {
+        physical_plan::Action::Collect { plan: logical_plan } => {
             println!("Logical plan: {:?}", logical_plan);
 
             // create local execution context

--- a/rust/ballista/src/bin/executor.rs
+++ b/rust/ballista/src/bin/executor.rs
@@ -20,7 +20,7 @@ use ballista::arrow::ipc;
 use ballista::datafusion::execution::context::ExecutionContext;
 use ballista::serde::decode_protobuf;
 
-use ballista::{physical_plan, BALLISTA_VERSION};
+use ballista::{logical_plan, BALLISTA_VERSION};
 
 use arrow::record_batch::RecordBatch;
 use ballista::scheduler::create_job;
@@ -122,7 +122,7 @@ impl FlightService for FlightServiceImpl {
         let action = decode_protobuf(&request.cmd.to_vec()).map_err(|e| to_tonic_err(&e))?;
 
         match &action {
-            physical_plan::Action::Collect { plan: logical_plan } => {
+            logical_plan::Action::Collect { plan: logical_plan } => {
                 println!("Logical plan: {:?}", logical_plan);
 
                 let job = create_job(logical_plan).map_err(|e| to_tonic_err(&e))?;
@@ -240,9 +240,9 @@ fn schema_to_bytes(schema: &Schema) -> Vec<u8> {
     data.to_vec()
 }
 
-fn execute_action(action: &physical_plan::Action) -> Result<Results, Status> {
+fn execute_action(action: &logical_plan::Action) -> Result<Results, Status> {
     match &action {
-        physical_plan::Action::Collect { plan: logical_plan } => {
+        logical_plan::Action::Collect { plan: logical_plan } => {
             println!("Logical plan: {:?}", logical_plan);
 
             // create local execution context

--- a/rust/ballista/src/client.rs
+++ b/rust/ballista/src/client.rs
@@ -16,7 +16,7 @@ use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
 use crate::error::BallistaError;
-use crate::plan::Action;
+use crate::physical_plan::Action;
 use crate::protobuf;
 
 use crate::arrow::datatypes::Schema;

--- a/rust/ballista/src/client.rs
+++ b/rust/ballista/src/client.rs
@@ -16,7 +16,7 @@ use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
 use crate::error::BallistaError;
-use crate::physical_plan::Action;
+use crate::logical_plan::Action;
 use crate::protobuf;
 
 use crate::arrow::datatypes::Schema;

--- a/rust/ballista/src/dataframe.rs
+++ b/rust/ballista/src/dataframe.rs
@@ -30,7 +30,7 @@ use crate::datafusion::optimizer::utils::exprlist_to_fields;
 use crate::datafusion::sql::parser::{DFASTNode, DFParser};
 use crate::datafusion::sql::planner::{SchemaProvider, SqlToRel};
 use crate::error::{BallistaError, Result};
-use crate::physical_plan::Action;
+use crate::logical_plan::Action;
 
 pub const CSV_BATCH_SIZE: &str = "ballista.csv.batchSize";
 

--- a/rust/ballista/src/dataframe.rs
+++ b/rust/ballista/src/dataframe.rs
@@ -30,7 +30,7 @@ use crate::datafusion::optimizer::utils::exprlist_to_fields;
 use crate::datafusion::sql::parser::{DFASTNode, DFParser};
 use crate::datafusion::sql::planner::{SchemaProvider, SqlToRel};
 use crate::error::{BallistaError, Result};
-use crate::plan::Action;
+use crate::physical_plan::Action;
 
 pub const CSV_BATCH_SIZE: &str = "ballista.csv.batchSize";
 

--- a/rust/ballista/src/execution_plan.rs
+++ b/rust/ballista/src/execution_plan.rs
@@ -17,9 +17,7 @@
 //! The execution plan is (will be) generated from the physical plan and there may be multiple
 //! implementations for these traits e.g. interpreted versus code-generated and CPU vs GPU.
 
-use crate::arrow::datatypes::Schema;
 use crate::arrow::record_batch::RecordBatch;
-use crate::datafusion::logicalplan::LogicalPlan;
 use crate::error::Result;
 use crate::physical_plan::{Partitioning, SortOrder};
 
@@ -60,7 +58,8 @@ pub trait BinaryExec: ExecutionPlan {
     }
 }
 
-/// Batch of columnar data
+/// Batch of columnar data. Just a wrapper around Arrow's RecordBatch for now but may change later.
+#[allow(dead_code)]
 pub struct ColumnarBatch {
     record_batch: RecordBatch,
 }

--- a/rust/ballista/src/execution_plan.rs
+++ b/rust/ballista/src/execution_plan.rs
@@ -1,0 +1,65 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ballista Execution Plan (Experimental).
+//!
+//! The execution plan is (will be) generated from the physical plan and there may be multiple
+//! implementations for these traits e.g. interpreted versus code-generated and CPU vs GPU.
+
+use crate::arrow::datatypes::Schema;
+use crate::arrow::record_batch::RecordBatch;
+use crate::datafusion::logicalplan::LogicalPlan;
+use crate::physical_plan::{Partitioning, SortOrder};
+
+/// Base trait for all operators
+pub trait ExecutionPlan {
+    /// Specifies how data is partitioned across different nodes in the cluster
+    fn output_partitioning(&self) -> Partitioning;
+    /// Specifies how data is ordered in each partition
+    fn output_ordering(&self) -> Vec<SortOrder>;
+    /// Specifies the data distribution requirements of all the children for this operator
+    fn required_child_ordering(&self) -> Vec<Vec<SortOrder>>;
+    /// Runs this query returning a stream of colymnar batches
+    fn execute(&self); //TODO decide on return type to represent stream of record batches
+    /// Runs this query returning the full results
+    fn execute_collect(&self) -> Vec<ColumnarBatch>;
+    /// Runs this query returning the first `n` rows
+    fn execute_take(&self, n: usize) -> Vec<ColumnarBatch>;
+    /// Runs this query returning the last `n` rows
+    fn execute_tail(&self, n: usize) -> Vec<ColumnarBatch>;
+    /// Returns the children of this operator
+    fn children(&self) -> Vec<Box<dyn ExecutionPlan>>;
+}
+
+pub trait UnaryExec: ExecutionPlan {
+    fn child(&self) -> Box<dyn ExecutionPlan>;
+
+    fn children(&self) -> Vec<Box<dyn ExecutionPlan>> {
+        vec![self.child()]
+    }
+}
+
+pub trait BinaryExec: ExecutionPlan {
+    fn left(&self) -> Box<dyn ExecutionPlan>;
+    fn right(&self) -> Box<dyn ExecutionPlan>;
+
+    fn children(&self) -> Vec<Box<dyn ExecutionPlan>> {
+        vec![self.left(), self.right()]
+    }
+}
+
+/// Batch of columnar data
+pub struct ColumnarBatch {
+    record_batch: RecordBatch,
+}

--- a/rust/ballista/src/execution_plan.rs
+++ b/rust/ballista/src/execution_plan.rs
@@ -20,6 +20,7 @@
 use crate::arrow::datatypes::Schema;
 use crate::arrow::record_batch::RecordBatch;
 use crate::datafusion::logicalplan::LogicalPlan;
+use crate::error::Result;
 use crate::physical_plan::{Partitioning, SortOrder};
 
 /// Base trait for all operators
@@ -33,11 +34,11 @@ pub trait ExecutionPlan {
     /// Runs this query returning a stream of colymnar batches
     fn execute(&self); //TODO decide on return type to represent stream of record batches
     /// Runs this query returning the full results
-    fn execute_collect(&self) -> Vec<ColumnarBatch>;
+    fn execute_collect(&self) -> Result<Vec<ColumnarBatch>>;
     /// Runs this query returning the first `n` rows
-    fn execute_take(&self, n: usize) -> Vec<ColumnarBatch>;
+    fn execute_take(&self, n: usize) -> Result<Vec<ColumnarBatch>>;
     /// Runs this query returning the last `n` rows
-    fn execute_tail(&self, n: usize) -> Vec<ColumnarBatch>;
+    fn execute_tail(&self, n: usize) -> Result<Vec<ColumnarBatch>>;
     /// Returns the children of this operator
     fn children(&self) -> Vec<Box<dyn ExecutionPlan>>;
 }

--- a/rust/ballista/src/lib.rs
+++ b/rust/ballista/src/lib.rs
@@ -30,6 +30,7 @@ pub mod client;
 pub mod cluster;
 pub mod dataframe;
 pub mod error;
+pub mod execution_plan;
 pub mod logical_plan;
 pub mod physical_plan;
 pub mod scheduler;

--- a/rust/ballista/src/logical_plan.rs
+++ b/rust/ballista/src/logical_plan.rs
@@ -12,26 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Ballista is a proof-of-concept distributed compute platform based on Kubernetes and Apache Arrow.
+//! Ballista Logical Plan
 
-pub use arrow;
-pub use datafusion;
-pub use sqlparser;
+use crate::datafusion::logicalplan::LogicalPlan;
 
-// include the generated protobuf source as a submodule
-#[allow(clippy::all)]
-pub mod protobuf {
-    include!(concat!(env!("OUT_DIR"), "/ballista.protobuf.rs"));
+/// Action that can be sent to an executor
+#[derive(Debug, Clone)]
+pub enum Action {
+    /// Execute the query and return the results
+    Collect { plan: LogicalPlan },
+    /// Execute the query and write the results to CSV
+    WriteCsv { plan: LogicalPlan, path: String },
+    /// Execute the query and write the results to Parquet
+    WriteParquet { plan: LogicalPlan, path: String },
 }
-
-pub const BALLISTA_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-pub mod client;
-pub mod cluster;
-pub mod dataframe;
-pub mod error;
-pub mod logical_plan;
-pub mod physical_plan;
-pub mod scheduler;
-pub mod serde;
-pub mod utils;

--- a/rust/ballista/src/physical_plan.rs
+++ b/rust/ballista/src/physical_plan.rs
@@ -18,6 +18,7 @@ use crate::arrow::datatypes::Schema;
 use crate::arrow::record_batch::RecordBatch;
 use crate::datafusion::logicalplan::LogicalPlan;
 
+///
 #[derive(Debug, Clone)]
 pub enum Action {
     Collect { plan: LogicalPlan },

--- a/rust/ballista/src/physical_plan.rs
+++ b/rust/ballista/src/physical_plan.rs
@@ -23,8 +23,6 @@
 //! The physical plan also accounts for partitioning and ordering of data between operators.
 
 use crate::arrow::datatypes::Schema;
-use crate::arrow::record_batch::RecordBatch;
-use crate::datafusion::logicalplan::LogicalPlan;
 
 #[derive(Debug, Clone)]
 pub enum PhysicalPlan {

--- a/rust/ballista/src/plan.rs
+++ b/rust/ballista/src/plan.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::arrow::datatypes::Schema;
 use crate::datafusion::logicalplan::LogicalPlan;
 
 #[derive(Debug, Clone)]
@@ -19,4 +20,105 @@ pub enum Action {
     Collect { plan: LogicalPlan },
     WriteCsv { plan: LogicalPlan, path: String },
     WriteParquet { plan: LogicalPlan, path: String },
+}
+
+#[derive(Debug, Clone)]
+pub enum PhysicalPlan {
+    /// Projection.
+    Project,
+    /// Filter a.k.a predicate.
+    Filter(Expression),
+    /// Take the first `limit` elements of the child's single output partition.
+    GlobalLimit,
+    /// Limit to be applied to each partition.
+    LocalLimit,
+    /// Sort on one or more sorting expressions.
+    Sort(SortExec),
+    /// Hash aggregate
+    HashAggregate(HashAggregateExec),
+    /// Performs a hash join of two child relations by first shuffling the data using the join keys.
+    ShuffledHashJoin(ShuffledHashJoinExec),
+    /// Performs a shuffle that will result in the desired partitioning.
+    ShuffleExchange(ShuffleExchangeExec),
+    /// Scans a partitioned data source
+    FileScan(FileScanExec),
+}
+
+#[derive(Debug, Clone)]
+pub enum JoinType {
+    Inner,
+}
+
+#[derive(Debug, Clone)]
+pub enum BuildSide {
+    BuildLeft,
+    BuildRight,
+}
+
+#[derive(Debug, Clone)]
+pub enum SortDirection {
+    Ascending,
+    Descending,
+}
+
+#[derive(Debug, Clone)]
+pub enum NullOrdering {
+    NullsFirst,
+    NullsLast,
+}
+
+#[derive(Debug, Clone)]
+pub enum Partitioning {
+    UnknownPartitioning(usize),
+    HashPartitioning(usize, Vec<Expression>),
+}
+
+#[derive(Debug, Clone)]
+pub struct FileScanExec {
+    projection: Option<Vec<usize>>,
+    partition_filters: Option<Vec<Expression>>,
+    data_filters: Option<Vec<Expression>>,
+    output_schema: Box<Schema>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShuffleExchangeExec {
+    child: Box<PhysicalPlan>,
+    output_partitioning: Partitioning,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShuffledHashJoinExec {
+    left_keys: Vec<Expression>,
+    right_keys: Vec<Expression>,
+    build_side: BuildSide,
+    join_type: JoinType,
+    left: Box<PhysicalPlan>,
+    right: Box<PhysicalPlan>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SortOrder {
+    child: Box<Expression>,
+    direction: SortDirection,
+    null_ordering: NullOrdering,
+}
+
+#[derive(Debug, Clone)]
+pub struct SortExec {
+    sort_order: Vec<SortOrder>,
+    child: Box<PhysicalPlan>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HashAggregateExec {
+    group_expr: Vec<Expression>,
+    aggr_expr: Vec<Expression>,
+    child: Box<PhysicalPlan>,
+}
+
+/// Physical expression
+#[derive(Debug, Clone)]
+pub enum Expression {
+    Column(usize),
 }

--- a/rust/ballista/src/plan.rs
+++ b/rust/ballista/src/plan.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Ballista Physical Plan (Experimental)
+
 use crate::arrow::datatypes::Schema;
 use crate::datafusion::logicalplan::LogicalPlan;
 
@@ -25,13 +27,13 @@ pub enum Action {
 #[derive(Debug, Clone)]
 pub enum PhysicalPlan {
     /// Projection.
-    Project,
+    Project(ProjectExec),
     /// Filter a.k.a predicate.
-    Filter(Expression),
+    Filter(FilterExec),
     /// Take the first `limit` elements of the child's single output partition.
-    GlobalLimit,
+    GlobalLimit(GlobalLimitExec),
     /// Limit to be applied to each partition.
-    LocalLimit,
+    LocalLimit(LocalLimitExec),
     /// Sort on one or more sorting expressions.
     Sort(SortExec),
     /// Hash aggregate
@@ -71,6 +73,30 @@ pub enum NullOrdering {
 pub enum Partitioning {
     UnknownPartitioning(usize),
     HashPartitioning(usize, Vec<Expression>),
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectExec {
+    child: Box<PhysicalPlan>,
+    projection: Vec<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterExec {
+    child: Box<PhysicalPlan>,
+    filter: Box<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GlobalLimitExec {
+    child: Box<PhysicalPlan>,
+    limit: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalLimitExec {
+    child: Box<PhysicalPlan>,
+    limit: usize,
 }
 
 #[derive(Debug, Clone)]

--- a/rust/ballista/src/serde/from_proto.rs
+++ b/rust/ballista/src/serde/from_proto.rs
@@ -21,7 +21,7 @@ use crate::datafusion::logicalplan::{
 };
 
 use crate::error::{ballista_error, BallistaError};
-use crate::physical_plan::Action;
+use crate::logical_plan::Action;
 use crate::protobuf;
 
 impl TryInto<LogicalPlan> for protobuf::LogicalPlanNode {

--- a/rust/ballista/src/serde/from_proto.rs
+++ b/rust/ballista/src/serde/from_proto.rs
@@ -21,7 +21,7 @@ use crate::datafusion::logicalplan::{
 };
 
 use crate::error::{ballista_error, BallistaError};
-use crate::plan::Action;
+use crate::physical_plan::Action;
 use crate::protobuf;
 
 impl TryInto<LogicalPlan> for protobuf::LogicalPlanNode {

--- a/rust/ballista/src/serde/mod.rs
+++ b/rust/ballista/src/serde/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::error::BallistaError;
-use crate::physical_plan::Action;
+use crate::logical_plan::Action;
 use crate::protobuf;
 
 use prost::Message;
@@ -37,6 +37,7 @@ mod tests {
     use crate::datafusion::execution::physical_plan::csv::CsvReadOptions;
     use crate::datafusion::logicalplan::{col, lit_str, Expr, LogicalPlanBuilder};
     use crate::error::Result;
+    use crate::logical_plan::Action;
     use crate::physical_plan::*;
     use crate::protobuf;
     use std::convert::TryInto;

--- a/rust/ballista/src/serde/mod.rs
+++ b/rust/ballista/src/serde/mod.rs
@@ -38,7 +38,6 @@ mod tests {
     use crate::datafusion::logicalplan::{col, lit_str, Expr, LogicalPlanBuilder};
     use crate::error::Result;
     use crate::logical_plan::Action;
-    use crate::physical_plan::*;
     use crate::protobuf;
     use std::convert::TryInto;
 

--- a/rust/ballista/src/serde/mod.rs
+++ b/rust/ballista/src/serde/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::error::BallistaError;
-use crate::plan::Action;
+use crate::physical_plan::Action;
 use crate::protobuf;
 
 use prost::Message;
@@ -37,7 +37,7 @@ mod tests {
     use crate::datafusion::execution::physical_plan::csv::CsvReadOptions;
     use crate::datafusion::logicalplan::{col, lit_str, Expr, LogicalPlanBuilder};
     use crate::error::Result;
-    use crate::plan::*;
+    use crate::physical_plan::*;
     use crate::protobuf;
     use std::convert::TryInto;
 

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::error::BallistaError;
-use crate::plan::Action;
+use crate::physical_plan::Action;
 use crate::protobuf;
 
 use crate::datafusion::logicalplan::{Expr, LogicalPlan, ScalarValue};

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::error::BallistaError;
-use crate::physical_plan::Action;
+use crate::logical_plan::Action;
 use crate::protobuf;
 
 use crate::datafusion::logicalplan::{Expr, LogicalPlan, ScalarValue};


### PR DESCRIPTION
In order to be able to execute distributed queries, we need a physical plan with support for distributed operations such as shuffles. This PR adds those data structures based on the equivalents defined in Apache Spark.