### PR TITLE
Implement basic scheduler to create Job (DAG of stages) from a physical query plan

### DIFF
--- a/proto/ballista.proto
+++ b/proto/ballista.proto
@@ -6,6 +6,10 @@ option java_multiple_files = true;
 option java_package = "org.ballistacompute.protobuf";
 option java_outer_classname = "BallistaProto";
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Actions
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
 message Action {
 
   // interactive query
@@ -14,6 +18,10 @@ message Action {
   //TODO: write_csv, write_parquet, repartition, etc
 
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Logical Plan
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 // logical expressions
 message LogicalExprNode {
@@ -99,6 +107,62 @@ message AggregateNode {
 message LimitNode {
   uint32 limit = 1;
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Physical Plan
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// PhysicalPlanNode is a nested type
+message PhysicalPlanNode {
+
+  PhysicalPlanNode input = 1;
+
+  ScanExecNode scan = 10;
+  ProjectionExecNode projection = 20;
+  SelectionExecNode selection = 21;
+  GlobalLimitExecNode global_limit = 22;
+  LocalLimitExecNode local_limit = 23;
+  HashAggregateExecNode hash_aggregate = 30;
+  ShuffleExecNode shuffle = 40;
+}
+
+message ScanExecNode {
+  string path = 1;
+  repeated string projection = 2;
+  Schema schema = 3;
+  string file_format = 4; // parquet or csv
+  bool has_header = 5; // csv specific
+}
+
+message ProjectionExecNode {
+  repeated LogicalExprNode expr = 1;
+}
+
+message SelectionExecNode {
+  LogicalExprNode expr = 2;
+}
+
+message HashAggregateExecNode {
+  repeated LogicalExprNode group_expr = 1;
+  repeated LogicalExprNode aggr_expr = 2;
+}
+
+message ShuffleExecNode {
+
+}
+
+message GlobalLimitExecNode {
+  uint32 limit = 1;
+}
+
+message LocalLimitExecNode {
+  uint32 limit = 1;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Arrow Data Types
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 message Schema {
   repeated Field columns = 1;

--- a/proto/ballista.proto
+++ b/proto/ballista.proto
@@ -142,9 +142,15 @@ message SelectionExecNode {
   LogicalExprNode expr = 2;
 }
 
+enum AggregateMode {
+  PARTIAL = 0;
+  FINAL = 1;
+}
+
 message HashAggregateExecNode {
   repeated LogicalExprNode group_expr = 1;
   repeated LogicalExprNode aggr_expr = 2;
+  AggregateMode mode = 3;
 }
 
 message ShuffleExecNode {
@@ -159,6 +165,16 @@ message LocalLimitExecNode {
   uint32 limit = 1;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Scheduling
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+message Task {
+  string job_uuid = 1;
+  uint32 stage_id = 2;
+  uint32 task_id = 3;
+  PhysicalPlanNode plan = 4;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Arrow Data Types

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -622,6 +622,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "distributed-query"
+version = "0.3.0-SNAPSHOT"
+dependencies = [
+ "ballista",
+ "tokio 0.2.21",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "benchmarks",
     "examples/apache-spark-rust-bindings",
     "examples/parallel-aggregate",
+    "examples/distributed-query",
 ]

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -6,6 +6,10 @@ option java_multiple_files = true;
 option java_package = "org.ballistacompute.protobuf";
 option java_outer_classname = "BallistaProto";
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Actions
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
 message Action {
 
   // interactive query
@@ -14,6 +18,10 @@ message Action {
   //TODO: write_csv, write_parquet, repartition, etc
 
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Logical Plan
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 // logical expressions
 message LogicalExprNode {
@@ -99,6 +107,62 @@ message AggregateNode {
 message LimitNode {
   uint32 limit = 1;
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Physical Plan
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// PhysicalPlanNode is a nested type
+message PhysicalPlanNode {
+
+  PhysicalPlanNode input = 1;
+
+  ScanExecNode scan = 10;
+  ProjectionExecNode projection = 20;
+  SelectionExecNode selection = 21;
+  GlobalLimitExecNode global_limit = 22;
+  LocalLimitExecNode local_limit = 23;
+  HashAggregateExecNode hash_aggregate = 30;
+  ShuffleExecNode shuffle = 40;
+}
+
+message ScanExecNode {
+  string path = 1;
+  repeated string projection = 2;
+  Schema schema = 3;
+  string file_format = 4; // parquet or csv
+  bool has_header = 5; // csv specific
+}
+
+message ProjectionExecNode {
+  repeated LogicalExprNode expr = 1;
+}
+
+message SelectionExecNode {
+  LogicalExprNode expr = 2;
+}
+
+message HashAggregateExecNode {
+  repeated LogicalExprNode group_expr = 1;
+  repeated LogicalExprNode aggr_expr = 2;
+}
+
+message ShuffleExecNode {
+
+}
+
+message GlobalLimitExecNode {
+  uint32 limit = 1;
+}
+
+message LocalLimitExecNode {
+  uint32 limit = 1;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Arrow Data Types
+///////////////////////////////////////////////////////////////////////////////////////////////////
 
 message Schema {
   repeated Field columns = 1;

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -142,9 +142,15 @@ message SelectionExecNode {
   LogicalExprNode expr = 2;
 }
 
+enum AggregateMode {
+  PARTIAL = 0;
+  FINAL = 1;
+}
+
 message HashAggregateExecNode {
   repeated LogicalExprNode group_expr = 1;
   repeated LogicalExprNode aggr_expr = 2;
+  AggregateMode mode = 3;
 }
 
 message ShuffleExecNode {
@@ -159,6 +165,16 @@ message LocalLimitExecNode {
   uint32 limit = 1;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Ballista Scheduling
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+message Task {
+  string job_uuid = 1;
+  uint32 stage_id = 2;
+  uint32 task_id = 3;
+  PhysicalPlanNode plan = 4;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Arrow Data Types

--- a/rust/ballista/src/execution/filter.rs
+++ b/rust/ballista/src/execution/filter.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct FilterExec {
-    child: Rc<PhysicalPlan>,
+    pub(crate) child: Rc<PhysicalPlan>,
 }
 
 impl ExecutionPlan for FilterExec {

--- a/rust/ballista/src/execution/parquet_scan.rs
+++ b/rust/ballista/src/execution/parquet_scan.rs
@@ -38,7 +38,7 @@ type MaybeColumnarBatch = Result<Option<ColumnarBatch>>;
 #[derive(Debug, Clone)]
 pub struct ParquetScanExec {
     pub(crate) path: String,
-    filenames: Vec<String>,
+    pub(crate) filenames: Vec<String>,
     projection: Option<Vec<usize>>,
 }
 

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -108,9 +108,9 @@ pub enum ColumnarValue {
 #[derive(Clone)]
 pub enum PhysicalPlan {
     /// Projection.
-    Projection(ProjectionExec),
+    Projection(Rc<ProjectionExec>),
     /// Filter a.k.a predicate.
-    Filter(FilterExec),
+    Filter(Rc<FilterExec>),
     /// Hash aggregate
     HashAggregate(Rc<HashAggregateExec>),
     /// Performs a hash join of two child relations by first shuffling the data using the join keys.
@@ -118,17 +118,17 @@ pub enum PhysicalPlan {
     /// Performs a shuffle that will result in the desired partitioning.
     ShuffleExchange(Rc<ShuffleExchangeExec>),
     /// Scans a partitioned data source
-    ParquetScan(ParquetScanExec),
+    ParquetScan(Rc<ParquetScanExec>),
 }
 
 impl PhysicalPlan {
     pub fn as_execution_plan(&self) -> Rc<dyn ExecutionPlan> {
         match self {
-            Self::Projection(exec) => Rc::new(exec.clone()),
-            Self::Filter(exec) => Rc::new(exec.clone()),
-            Self::HashAggregate(exec) => Rc::new(exec.as_ref().clone()),
-            Self::ParquetScan(exec) => Rc::new(exec.clone()),
-            Self::ShuffleExchange(exec) => Rc::new(exec.as_ref().clone()),
+            Self::Projection(exec) => exec.clone(),
+            Self::Filter(exec) => exec.clone(),
+            Self::HashAggregate(exec) => exec.clone(),
+            Self::ParquetScan(exec) => exec.clone(),
+            Self::ShuffleExchange(exec) => exec.clone(),
             _ => unimplemented!(),
         }
     }

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -26,6 +26,8 @@ use std::fmt;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use futures::stream::BoxStream;
+
 use crate::arrow::array::ArrayRef;
 use crate::arrow::record_batch::RecordBatch;
 use crate::datafusion::logicalplan::ScalarValue;
@@ -38,7 +40,6 @@ use crate::execution::filter::FilterExec;
 use crate::execution::parquet_scan::ParquetScanExec;
 use crate::execution::projection::ProjectionExec;
 use crate::execution::shuffled_hash_join::ShuffledHashJoinExec;
-use futures::stream::BoxStream;
 
 /// Stream of columnar batches using futures
 pub type ColumnarBatchStream = BoxStream<'static, ColumnarBatch>;

--- a/rust/ballista/src/execution/projection.rs
+++ b/rust/ballista/src/execution/projection.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct ProjectionExec {
-    child: Rc<PhysicalPlan>,
+    pub(crate) child: Rc<PhysicalPlan>,
 }
 
 impl ProjectionExec {

--- a/rust/ballista/src/execution/scheduler.rs
+++ b/rust/ballista/src/execution/scheduler.rs
@@ -15,6 +15,7 @@
 //! The scheduler is responsible for breaking a physical query plan down into stages and tasks
 //! and co-ordinating execution of these stages and tasks across the cluster.
 
+use std::cell::RefCell;
 use std::rc::Rc;
 use uuid::Uuid;
 
@@ -33,7 +34,7 @@ pub struct Job {
     pub id: Uuid,
     /// A list of stages within this job. There can be dependencies between stages to form
     /// a directed acyclic graph (DAG).
-    pub stages: Vec<Box<Stage>>,
+    pub stages: Vec<Rc<Stage>>,
 }
 
 /// A query stage consists of tasks. Typically, tasks map to partitions.
@@ -43,24 +44,89 @@ pub struct Stage {
     /// A list of stages that must complete before this stage can execute.
     pub prior_stages: Vec<usize>,
     /// A list of tasks in this stage. One task per partition currently.
-    pub tasks: Vec<Box<Task>>,
+    pub tasks: Vec<Task>,
 }
 
-/// A Task represents a physical query plan to be executed against a partition.
+impl Stage {
+    /// Create a new empty stage with the specified id.
+    fn new(id: usize) -> Self {
+        Self {
+            id,
+            prior_stages: vec![],
+            tasks: vec![]
+        }
+    }
+}
+
+/// A Task represents a physical query plan to be executed against a partition (and later, possibly
+/// against partition splits).
 pub struct Task {
-    /// Stage id which is unique within a stage.
+    /// Task id which is unique within a stage.
     pub id: usize,
     /// The partition that this task will execute against
     pub partition_id: usize,
+    /// The split or chunk of the partition. Currently unused.
+    pub split_id: usize,
     /// The physical plan to execute
-    pub plan: Box<PhysicalPlan>,
+    pub plan: Rc<PhysicalPlan>,
+}
+
+impl Task {
+    pub fn new(id: usize, partition_id: usize, split_id: usize, plan: Rc<PhysicalPlan>) -> Self {
+        Self { id, partition_id, split_id, plan }
+    }
+}
+
+pub struct Scheduler {
+    current_stage: Option<Rc<RefCell<Stage>>>,
+    next_stage_id: usize,
+    next_task_id: usize,
+}
+
+impl Scheduler {
+
+    fn new() -> Self {
+        Self {
+            current_stage: Some(Rc::new(RefCell::new(Stage::new(0)))),
+            next_stage_id: 1,
+            next_task_id: 0,
+        }
+    }
+
+    fn create_dag(&mut self, plan: Rc<PhysicalPlan>) {
+        match plan.as_ref() {
+            PhysicalPlan::HashAggregate(exec) => {
+                self.create_dag(exec.child.clone());
+            }
+            PhysicalPlan::ShuffleExchange(exec) => {
+                self.create_dag(exec.child.clone());
+            }
+            PhysicalPlan::ParquetScan(exec) => {
+                let mut current_stage = self.current_stage.as_ref()
+                    .expect("stage must exist when creating ParquetScan tasks")
+                    .borrow_mut();
+
+                // create one task per file for now but later we may want finer granularity of one
+                // task per chunk or split.
+                for (i, _) in exec.filenames.iter().enumerate() {
+                    current_stage.tasks.push(Task::new(self.next_task_id, i, 0, plan.clone()));
+                    self.next_task_id += 1;
+
+                }
+                    //.for_each(|(i, filename)| current_stage.add_task(i, plan.clone()));
+            }
+            _ => {
+                unimplemented!()
+            }
+        }
+    }
 }
 
 pub fn create_physical_plan(plan: &LogicalPlan) -> Result<Rc<PhysicalPlan>> {
     match plan {
         LogicalPlan::Projection { input, .. } => {
             let exec = ProjectionExec::new(create_physical_plan(input)?);
-            Ok(Rc::new(PhysicalPlan::Projection(exec)))
+            Ok(Rc::new(PhysicalPlan::Projection(Rc::new(exec))))
         }
         LogicalPlan::Aggregate {
             input,
@@ -105,7 +171,7 @@ pub fn create_physical_plan(plan: &LogicalPlan) -> Result<Rc<PhysicalPlan>> {
         }
         LogicalPlan::ParquetScan { path, .. } => {
             let exec = ParquetScanExec::try_new(&path, None)?;
-            Ok(Rc::new(PhysicalPlan::ParquetScan(exec)))
+            Ok(Rc::new(PhysicalPlan::ParquetScan(Rc::new(exec))))
         }
         other => Err(BallistaError::General(format!("unsupported {:?}", other))),
     }
@@ -155,25 +221,27 @@ pub fn ensure_requirements(plan: &PhysicalPlan) -> Result<Rc<PhysicalPlan>> {
 
 #[cfg(test)]
 mod tests {
-    // use super::*;
-    // use crate::dataframe::{col, sum, Context};
-    // use std::collections::HashMap;
-    //use crate::arrow::datatypes::{Schema, Field, DataType};
+    use super::*;
+    use crate::dataframe::{col, sum, Context};
+    use std::collections::HashMap;
 
-    // #[test]
-    // fn create_plan() -> Result<()> {
-    //     let ctx = Context::local(HashMap::new());
-    //
-    //     let df = ctx
-    //         .read_parquet("/mnt/nyctaxi/parquet/year=2019", None)?
-    //         .aggregate(vec![col("passenger_count")], vec![sum(col("fare_amount"))])?;
-    //
-    //     let plan = df.logical_plan();
-    //
-    //     let plan = create_physical_plan(&plan)?;
-    //     let plan = ensure_requirements(&plan)?;
-    //     println!("{:?}", plan);
-    //
-    //     Ok(())
-    // }
+    #[test]
+    fn create_plan() -> Result<()> {
+        let ctx = Context::local(HashMap::new());
+
+        let df = ctx
+            .read_parquet("/mnt/nyctaxi/parquet/year=2019", None)?
+            .aggregate(vec![col("passenger_count")], vec![sum(col("fare_amount"))])?;
+
+        let plan = df.logical_plan();
+
+        let plan = create_physical_plan(&plan)?;
+        let plan = ensure_requirements(&plan)?;
+        println!("{:?}", plan);
+
+        let mut scheduler = Scheduler::new();
+        scheduler.create_dag(plan);
+
+        Ok(())
+    }
 }

--- a/rust/ballista/src/execution/shuffle_exchange.rs
+++ b/rust/ballista/src/execution/shuffle_exchange.rs
@@ -21,7 +21,7 @@ use crate::execution::physical_plan::{
 
 #[derive(Debug, Clone)]
 pub struct ShuffleExchangeExec {
-    pub child: Rc<PhysicalPlan>,
+    pub(crate) child: Rc<PhysicalPlan>,
     output_partitioning: Partitioning,
 }
 

--- a/rust/ballista/src/execution/shuffle_reader.rs
+++ b/rust/ballista/src/execution/shuffle_reader.rs
@@ -14,26 +14,16 @@
 
 use crate::error::Result;
 use crate::execution::physical_plan::{ColumnarBatchStream, ExecutionPlan};
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
-struct ShuffleReaderExec {
-    partitions: Vec<ShufflePartition>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-struct ShufflePartition {
-    executor_uuid: Uuid,
-    job_uuid: Vec<Uuid>,
+pub struct ShuffleReaderExec {
+    // query stage that produced the shuffle output that this reader needs to read
+    pub stage_id: usize,
 }
 
 impl ExecutionPlan for ShuffleReaderExec {
-    fn execute(&self, partition_index: usize) -> Result<ColumnarBatchStream> {
-        let _part = &self.partitions[partition_index];
-
+    fn execute(&self, _partition_index: usize) -> Result<ColumnarBatchStream> {
         // TODO send Flight request to the executor asking for the partition(s)
-
         unimplemented!()
     }
 }

--- a/rust/ballista/src/execution/shuffle_reader.rs
+++ b/rust/ballista/src/execution/shuffle_reader.rs
@@ -25,7 +25,7 @@ struct ShuffleReaderExec {
 #[derive(Debug, Clone)]
 struct ShufflePartition {
     executor_uuid: Uuid,
-    partition_uuid: Vec<Uuid>,
+    job_uuid: Vec<Uuid>,
 }
 
 impl ExecutionPlan for ShuffleReaderExec {

--- a/rust/ballista/src/execution/shuffled_hash_join.rs
+++ b/rust/ballista/src/execution/shuffled_hash_join.rs
@@ -18,6 +18,6 @@ use crate::execution::physical_plan::PhysicalPlan;
 
 #[derive(Debug, Clone)]
 pub struct ShuffledHashJoinExec {
-    left: Rc<PhysicalPlan>,
-    right: Rc<PhysicalPlan>,
+    pub(crate) left: Rc<PhysicalPlan>,
+    pub(crate) right: Rc<PhysicalPlan>,
 }

--- a/rust/examples/distributed-query/Cargo.toml
+++ b/rust/examples/distributed-query/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "distributed-query"
+version = "0.3.0-SNAPSHOT"
+authors = ["Andy Grove <andygrove73@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ballista = { path="../../ballista" }
+tokio = { version = "0.2", features = ["full"] }

--- a/rust/examples/distributed-query/README.md
+++ b/rust/examples/distributed-query/README.md
@@ -1,0 +1,27 @@
+# Distributed Query Execution
+
+*NOTE: this is a work-in-progress and is not functional yet*
+
+This example shows how to manually create a Ballista cluster of Rust executors and run an aggregate query using those executors.
+
+## Prerequisites
+
+You will need to create a Ballista cluster in Kubernetes. This is documented in the [README](../../../kubernetes/README.md) in the top-level kubernetes folder.
+
+## Execute the query
+
+The example will create a logical query plan and submit it to the cluster for execution. The executor receiving the 
+query will create a physical plan and schedule execution in the cluster and then return the results.
+
+```bash
+cargo run
+``` 
+
+## Teardown
+
+Remove cluster:
+
+```bash
+kubectl delete -f parallel-aggregate-rs.yaml
+kubectl delete -f cluster-deployment.yaml
+```

--- a/rust/examples/distributed-query/src/main.rs
+++ b/rust/examples/distributed-query/src/main.rs
@@ -1,0 +1,55 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+extern crate ballista;
+use ballista::arrow::util::pretty;
+use ballista::dataframe::{max, Context};
+use ballista::datafusion::logicalplan::*;
+use ballista::error::Result;
+use ballista::BALLISTA_VERSION;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!(
+        "Ballista v{} Parallel Aggregate Query Example",
+        BALLISTA_VERSION
+    );
+
+    //TODO use command-line args
+    let nyc_taxi_path = "/mnt/nyctaxi";
+    let executor_host = "localhost";
+    let executor_port = 1234;
+
+    let start = Instant::now();
+    let ctx = Context::remote(executor_host, executor_port, HashMap::new());
+
+    let results = ctx
+        .read_parquet(nyc_taxi_path, None)?
+        .aggregate(vec![col("passenger_count")], vec![max(col("fare_amount"))])?
+        .collect()
+        .await?;
+
+    // print the results
+    pretty::print_batches(&results)?;
+
+    println!(
+        "Distributed query took {} seconds",
+        start.elapsed().as_secs()
+    );
+
+    Ok(())
+}

--- a/rust/examples/distributed-query/src/main.rs
+++ b/rust/examples/distributed-query/src/main.rs
@@ -24,10 +24,7 @@ use ballista::BALLISTA_VERSION;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    println!(
-        "Ballista v{} Parallel Aggregate Query Example",
-        BALLISTA_VERSION
-    );
+    println!("Ballista v{} Distributed Query Example", BALLISTA_VERSION);
 
     //TODO use command-line args
     let nyc_taxi_path = "/mnt/nyctaxi";


### PR DESCRIPTION
This PR introduces a basic scheduler capable of create a Job definition (DAG of stages) from a physical query plan.

Example:

```
Job 15aeb081-e515-44fa-a02c-6c5e3c59d16e has 2 stages:

Stage 0:

Stage 0 depends on stages [1].

HashAggregate: mode=Final, groupExpr=[#passenger_count], aggrExpr=[SUM(#fare_amount)]
  ShuffleReader: stage_id=1

Stage 1:

Stage 1 has no dependencies.

HashAggregate: mode=Partial, groupExpr=[#passenger_count], aggrExpr=[SUM(#fare_amount)]
  ParquetScan: "/mnt/nyctaxi/parquet/year=2019", partitions=12
```

It also lays some groundwork in defining the physical plan in protobuf format.