### PR TITLE
move linting logic into separate job to reduce CI runtime

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,18 +15,31 @@ env:
   TOOLCHAIN_VERSION: nightly-2020-05-14-x86_64-pc-windows-msvc
 
 jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup
+      run: rustup default ${RUSTUP_VERSION} && rustup component add clippy rustfmt
+    - name: Lint Ballista
+      run: cd rust && cargo clippy -- -D warnings
+    - name: Lint Integration Tests
+      run: cd integration-tests/rust && cargo clippy -- -D warnings
+    - name: Lint Benchmarks
+      run: cd benchmarks && cargo clippy -- -D warnings
+
   Ubuntu:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup
-      run: rustup default ${RUSTUP_VERSION} && rustup component add rustfmt clippy
+      run: rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
     - name: Build Ballista
-      run: cd rust && cargo clippy -- -Dwarnings && cargo build
+      run: cd rust && cargo build
     - name: Build Integration Tests
-      run: cd integration-tests/rust && cargo clippy -- -Dwarnings && cargo build
+      run: cd integration-tests/rust && cargo build
     - name: Build Benchmarks
-      run: cd benchmarks && cargo clippy -- -Dwarnings && cargo build
+      run: cd benchmarks && cargo build
     - name: Run tests
       run: cd rust && cargo test
 
@@ -37,13 +50,13 @@ jobs:
     - name: Setup
       run: |
         brew install rustup
-        rustup default ${RUSTUP_VERSION} && rustup component add rustfmt clippy
+        rustup default ${RUSTUP_VERSION} && rustup component add rustfmt
     - name: Build Ballista
-      run: cd rust && cargo clippy -- -Dwarnings && cargo build
+      run: cd rust && cargo build
     - name: Build Integration Tests
-      run: cd integration-tests/rust && cargo clippy -- -Dwarnings && cargo build
+      run: cd integration-tests/rust && cargo build
     - name: Build Benchmarks
-      run: cd benchmarks && cargo clippy -- -Dwarnings && cargo build
+      run: cd benchmarks && cargo build
     - name: Run tests
       run: cd rust && cargo test
 
@@ -60,16 +73,16 @@ jobs:
       run: |
         rustup default nightly-2020-05-14
         rustup toolchain install nightly-2020-05-14
-        rustup component add rustfmt clippy --toolchain nightly-2020-05-14-x86_64-pc-windows-msvc
+        rustup component add rustfmt --toolchain nightly-2020-05-14-x86_64-pc-windows-msvc
     - name: Build Ballista
       run: |
-        cd rust && cargo clippy -- -Dwarnings && cargo build
+        cd rust && cargo build
     - name: Build Integration Tests
       run: |
-        cd integration-tests/rust && cargo clippy -- -Dwarnings && cargo build
+        cd integration-tests/rust && cargo build
     - name: Build Becnhmarks
       run: |
-        cd benchmarks && cargo clippy -- -Dwarnings && cargo build
+        cd benchmarks && cargo build
     - name: Run tests
       run: |
         cd rust && cargo test


### PR DESCRIPTION
There is no need to run clippy on different platforms