### PR TITLE
[Rust] Integration test for hash agg using data generator

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "random-fast-rng",
  "reqwest 0.9.24",
  "smol",
  "sqlparser",
@@ -2114,6 +2115,21 @@ checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
 ]
+
+[[package]]
+name = "random-fast-rng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95784e84a571f44dc7fd4f0d3ab3f493d3c07b90d695450890490a89d83905a3"
+dependencies = [
+ "random-trait",
+]
+
+[[package]]
+name = "random-trait"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3186af2e04abe646626095b37293d7485027e8591c56430dfda49894a28447"
 
 [[package]]
 name = "rdrand"

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -30,6 +30,7 @@ crossbeam = "0.7"
 smol = "0.1.18"
 async-trait = "0.1.36"
 async-mutex = "1.1.5"
+random-fast-rng = "0.1.1"
 
 # For local development and debugging
 #arrow = { path = "../../../arrow/rust/arrow" }

--- a/rust/ballista/src/datagen.rs
+++ b/rust/ballista/src/datagen.rs
@@ -1,0 +1,127 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::arrow::array::{self, ArrayRef};
+use crate::arrow::datatypes::{DataType, Schema};
+use crate::error::Result;
+use crate::execution::physical_plan::{ColumnarBatch, ColumnarValue};
+
+use random_fast_rng::{FastRng, Random};
+
+/// Random data generator
+#[allow(dead_code)]
+pub struct DataGen {
+    rng: FastRng,
+}
+
+impl Default for DataGen {
+    fn default() -> Self {
+        DataGen::new()
+    }
+}
+
+#[allow(dead_code)]
+impl DataGen {
+    /// Create a data generator using a fixed seed for reproducible data.
+    pub fn new() -> Self {
+        Self {
+            rng: FastRng::seed(0, 0),
+        }
+    }
+
+    /// Generate an Array array with the specified data type and length
+    fn create_array(
+        &mut self,
+        data_type: &DataType,
+        nullable: bool,
+        len: usize,
+    ) -> Result<ArrayRef> {
+        match data_type {
+            DataType::Int64 => {
+                let mut builder = array::Int64Array::builder(len);
+                for _ in 0..len {
+                    if nullable && self.rng.get_u8() < 10 {
+                        builder.append_null()?;
+                    } else {
+                        builder.append_value(self.rng.get_u64() as i64)?;
+                    }
+                }
+                Ok(Arc::new(builder.finish()))
+            }
+            DataType::UInt64 => {
+                let mut builder = array::UInt64Array::builder(len);
+                for _ in 0..len {
+                    if nullable && self.rng.get_u8() < 10 {
+                        builder.append_null()?;
+                    } else {
+                        builder.append_value(self.rng.get_u64())?;
+                    }
+                }
+                Ok(Arc::new(builder.finish()))
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    /// Generate a columnar batch with the specified schema and length
+    pub fn create_batch(&mut self, schema: &Schema, len: usize) -> Result<ColumnarBatch> {
+        let columns: Vec<ArrayRef> = schema
+            .fields()
+            .iter()
+            .map(|f| self.create_array(f.data_type(), f.is_nullable(), len))
+            .collect::<Result<Vec<_>>>()?;
+
+        let columns: Vec<ColumnarValue> = columns
+            .iter()
+            .map(|c| ColumnarValue::Columnar(c.clone()))
+            .collect();
+
+        Ok(ColumnarBatch::from_values(&columns))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::datatypes::Field;
+
+    #[test]
+    fn create_primitive_array() -> Result<()> {
+        let mut gen = DataGen::new();
+        let array = gen.create_array(&DataType::Int64, true, 8)?;
+        assert_eq!(8, array.len());
+        let array = array
+            .as_any()
+            .downcast_ref::<array::Int64Array>()
+            .expect("cast failed");
+        assert_eq!(6650325416439211286, array.value(0));
+        assert_eq!(5068474728774271781, array.value(7));
+        Ok(())
+    }
+
+    #[test]
+    fn create_primitive_batch() -> Result<()> {
+        let mut gen = DataGen::new();
+        let schema = Schema::new(vec![
+            Field::new("c0", DataType::Int64, true),
+            Field::new("c1", DataType::UInt64, false),
+        ]);
+        let batch = gen.create_batch(&schema, 8)?;
+        assert_eq!(2, batch.num_columns());
+        assert_eq!(8, batch.num_rows());
+        Ok(())
+    }
+}

--- a/rust/ballista/src/execution/in_memory.rs
+++ b/rust/ballista/src/execution/in_memory.rs
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::arrow::datatypes::Schema;
+use crate::error::Result;
+use crate::execution::physical_plan::{
+    ColumnarBatch, ColumnarBatchIter, ColumnarBatchStream, ExecutionPlan,
+};
+
+use async_trait::async_trait;
+
+pub struct InMemoryTableScanExec {
+    data: Vec<ColumnarBatch>,
+}
+
+impl InMemoryTableScanExec {
+    pub fn new(data: Vec<ColumnarBatch>) -> Self {
+        Self { data }
+    }
+}
+
+impl ExecutionPlan for InMemoryTableScanExec {
+    fn schema(&self) -> Arc<Schema> {
+        self.data[0].schema()
+    }
+
+    fn execute(&self, _partition_index: usize) -> Result<ColumnarBatchStream> {
+        Ok(Arc::new(InMemoryTableScanIter::new(self.data.clone())))
+    }
+}
+
+pub struct InMemoryTableScanIter {
+    index: Arc<AtomicUsize>,
+    data: Vec<ColumnarBatch>,
+}
+
+impl InMemoryTableScanIter {
+    fn new(data: Vec<ColumnarBatch>) -> Self {
+        Self {
+            index: Arc::new(AtomicUsize::new(0)),
+            data,
+        }
+    }
+}
+
+#[async_trait]
+impl ColumnarBatchIter for InMemoryTableScanIter {
+    fn schema(&self) -> Arc<Schema> {
+        self.data[0].schema()
+    }
+
+    async fn next(&self) -> Result<Option<ColumnarBatch>> {
+        let index = self.index.load(Ordering::SeqCst);
+        if index < self.data.len() {
+            self.index.store(index + 1, Ordering::SeqCst);
+            Ok(Some(self.data[index].clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/rust/ballista/src/execution/mod.rs
+++ b/rust/ballista/src/execution/mod.rs
@@ -17,6 +17,7 @@
 pub mod expressions;
 pub mod filter;
 pub mod hash_aggregate;
+pub mod in_memory;
 pub mod parquet_scan;
 pub mod physical_plan;
 pub mod projection;

--- a/rust/ballista/src/lib.rs
+++ b/rust/ballista/src/lib.rs
@@ -32,6 +32,7 @@ pub const BALLISTA_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub mod client;
 pub mod cluster;
 pub mod dataframe;
+pub mod datagen;
 pub mod error;
 pub mod execution;
 pub mod logical_plan;


### PR DESCRIPTION
Use a data generator instead of reading from Parquet to simplify CI and also make it easier to test performance of hash agg independently of file io.

Also adds InMemoryTableScanExec.