### PR TITLE
Misc improvements

### DIFF
--- a/rust/ballista/src/distributed/scheduler.rs
+++ b/rust/ballista/src/distributed/scheduler.rs
@@ -394,7 +394,7 @@ pub fn create_physical_plan(plan: &LogicalPlan) -> Result<Arc<PhysicalPlan>> {
         LogicalPlan::ParquetScan {
             path, projection, ..
         } => {
-            let exec = ParquetScanExec::try_new(&path, projection.clone())?;
+            let exec = ParquetScanExec::try_new(&path, projection.clone(), 64 * 1024)?;
             Ok(Arc::new(PhysicalPlan::ParquetScan(Arc::new(exec))))
         }
         other => Err(BallistaError::General(format!("unsupported {:?}", other))),

--- a/rust/ballista/src/serde/from_proto.rs
+++ b/rust/ballista/src/serde/from_proto.rs
@@ -232,7 +232,7 @@ impl TryInto<ExecutionTask> for protobuf::Task {
                 port: loc.executor_port as usize,
             };
 
-            shuffle_locations.insert(shuffle_id, exec).unwrap();
+            shuffle_locations.insert(shuffle_id, exec);
         }
 
         Ok(ExecutionTask::new(
@@ -319,6 +319,7 @@ impl TryInto<PhysicalPlan> for protobuf::PhysicalPlanNode {
                     ParquetScanExec::try_new(
                         &scan.path,
                         Some(scan.projection.iter().map(|n| *n as usize).collect()),
+                        64 * 1024,
                     )?,
                 ))),
                 other => Err(ballista_error(&format!(

--- a/rust/examples/distributed-query/README.md
+++ b/rust/examples/distributed-query/README.md
@@ -11,8 +11,8 @@ etcd must be running locally.
 ### Start one or more executors
 
 ```bash
-cargo run --bin executor -- --mode etcd --port 50051
-cargo run --bin executor -- --mode etcd --port 50052
+cargo run --release --bin executor -- --mode etcd --port 50051
+cargo run --release --bin executor -- --mode etcd --port 50052
 ```
 
 ### Execute the query


### PR DESCRIPTION
- Use a bounded channel in ParquetScanExec to manage memory pressure better
- Fix a bug with an unwrap that was inadvertently introduced
- Move hard-coded batch sizes higher up .. eventually needs to be in a config