### PR TITLE
Added support to filters.

### DIFF
--- a/rust/ballista/tests/query_execution.rs
+++ b/rust/ballista/tests/query_execution.rs
@@ -6,6 +6,7 @@ use ballista::arrow::datatypes::{DataType, Field, Schema};
 use ballista::dataframe::{avg, count, max, min, sum};
 use ballista::datafusion::logicalplan::col_index;
 use ballista::distributed::executor::{DefaultContext, DiscoveryMode, ExecutorConfig};
+use ballista::execution::operators::FilterExec;
 use ballista::execution::operators::HashAggregateExec;
 use ballista::execution::operators::InMemoryTableScanExec;
 use ballista::execution::physical_plan::{AggregateMode, ColumnarBatchStream, PhysicalPlan};
@@ -13,63 +14,80 @@ use ballista::utils::datagen::DataGen;
 use std::collections::HashMap;
 use std::time::Instant;
 
+async fn execute(use_filter: bool) {
+    //TODO remove unwraps
+
+    let mut gen = DataGen::default();
+
+    let schema = Schema::new(vec![
+        Field::new("c0", DataType::Int8, true),
+        Field::new("c1", DataType::Int32, false),
+    ]);
+    let batch = gen.create_batch(&schema, 1024).unwrap();
+
+    let mut child = PhysicalPlan::InMemoryTableScan(Arc::new(InMemoryTableScanExec::new(vec![
+        batch.clone(),
+        batch,
+    ])));
+
+    if use_filter {
+        // WHERE col(0) >= col(0), which must not affect the final result
+        child = PhysicalPlan::Filter(Arc::new(FilterExec::new(
+            &child,
+            &col_index(0).gt_eq(&col_index(0)),
+        )));
+    }
+
+    let hash_agg = PhysicalPlan::HashAggregate(Arc::new(
+        HashAggregateExec::try_new(
+            AggregateMode::Partial,
+            vec![col_index(0)],
+            vec![
+                min(col_index(1)),
+                max(col_index(1)),
+                avg(col_index(1)),
+                sum(col_index(1)),
+                count(col_index(1)),
+            ],
+            Arc::new(child),
+        )
+        .unwrap(),
+    ));
+
+    let config = ExecutorConfig::new(DiscoveryMode::Standalone, "", 0, "");
+
+    let ctx = Arc::new(DefaultContext::new(&config, HashMap::new()));
+
+    let start = Instant::now();
+    let stream: ColumnarBatchStream = hash_agg.as_execution_plan().execute(ctx, 0).await.unwrap();
+    let mut results = vec![];
+    while let Some(batch) = stream.next().await.unwrap() {
+        results.push(batch);
+    }
+
+    let duration = start.elapsed();
+    println!("Took {} ms", duration.as_millis());
+
+    assert_eq!(1, results.len());
+
+    let batch = &results[0];
+
+    assert_eq!(251, batch.num_rows());
+    assert_eq!(6, batch.num_columns());
+}
+
 #[test]
 fn hash_aggregate() -> std::io::Result<()> {
     smol::run(async {
-        //TODO remove unwraps
+        execute(false).await;
+        std::io::Result::Ok(())
+    })
+}
 
-        let mut gen = DataGen::default();
-
-        let schema = Schema::new(vec![
-            Field::new("c0", DataType::Int8, true),
-            Field::new("c1", DataType::Int32, false),
-        ]);
-        let batch = gen.create_batch(&schema, 1024).unwrap();
-
-        let in_memory_exec =
-            PhysicalPlan::InMemoryTableScan(Arc::new(InMemoryTableScanExec::new(vec![
-                batch.clone(),
-                batch,
-            ])));
-
-        let hash_agg = PhysicalPlan::HashAggregate(Arc::new(
-            HashAggregateExec::try_new(
-                AggregateMode::Partial,
-                vec![col_index(0)],
-                vec![
-                    min(col_index(1)),
-                    max(col_index(1)),
-                    avg(col_index(1)),
-                    sum(col_index(1)),
-                    count(col_index(1)),
-                ],
-                Arc::new(in_memory_exec),
-            )
-            .unwrap(),
-        ));
-
-        let config = ExecutorConfig::new(DiscoveryMode::Standalone, "", 0, "");
-
-        let ctx = Arc::new(DefaultContext::new(&config, HashMap::new()));
-
-        let start = Instant::now();
-        let stream: ColumnarBatchStream =
-            hash_agg.as_execution_plan().execute(ctx, 0).await.unwrap();
-        let mut results = vec![];
-        while let Some(batch) = stream.next().await.unwrap() {
-            results.push(batch);
-        }
-
-        let duration = start.elapsed();
-        println!("Took {} ms", duration.as_millis());
-
-        assert_eq!(1, results.len());
-
-        let batch = &results[0];
-
-        assert_eq!(251, batch.num_rows());
-        assert_eq!(6, batch.num_columns());
-
+#[test]
+fn hash_aggregate_with_filter() -> std::io::Result<()> {
+    smol::run(async {
+        execute(true).await;
         std::io::Result::Ok(())
     })
 }


### PR DESCRIPTION
Closed #184.

Note that this currently fails the tests because we have not implemented comparison operators:

```
thread 'hash_aggregate_with_filter' panicked at 'called `Result::unwrap()` on an `Err` value: General("Unsupported binary operator GtEq")', ballista/tests/query_execution.rs:56:9
```

We need to push for that before this one.
