### PR TITLE
0.3.0-alpha-1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The foundational technologies in Ballista are:
 
 Ballista can be deployed in [Kubernetes](https://kubernetes.io/), or as a standalone cluster using [etcd](https://etcd.io/) for discovery.
 
-## Architecture Diagram
+## Architecture
 
 The following diagram highlights some of the integrations that will be possible with this unique architecture. Note 
 that not all components shown here are available yet.
@@ -38,31 +38,29 @@ that not all components shown here are available yet.
 
 ## How does this compare to Apache Spark?
 
-Ballista differs from Apache Spark in many ways.
+Although Ballista is largely inspired by Apache Spark, there are some key differences.
 
-- Due to the use of Rust, memory usage can be up to 100x lower than Apache Spark which means that more processing can 
-fit on a single node, reducing the overhead of distributed compute.
-- Also due to the use of Rust, there are no "cold start" overheads. The first run of a query can be up to 10x faster 
-than Apache Spark.
-- The use of Apache Arrow as the memory model and network protocol means that data can be exchanged between executors in
-any programming language with minimal serialization overhead.
-- Ballista is columnar rather than row-based, meaning that it can take advantage of vectorized processing both on the
-CPU (using SIMD) and on the GPU. GPU support isn't available yet but will be available in a future release.
+- The choice of Rust as the main execution language means that memory usage is deterministic and avoids the overhead of 
+GC pauses.
+- Ballista is designed from the ground up to use columnar data, enabling a number of efficiencies such as vectorized 
+processing (SIMD and GPU) and efficient compression. Although Spark does have some columnar support, it is still 
+largely row-based today.
+- The combination of Rust and Arrow provides excellent memory efficiency and memory usage can be 50x - 100x lower than 
+Apache Spark in some cases, which means that more processing can fit on a single node, reducing the overhead of 
+distributed compute.
+- The use of Apache Arrow as the memory model and network protocol means that data can be exchanged between executors 
+in any programming language with minimal serialization overhead.
 
 ## Example Rust Client
 
 ```rust
 #[tokio::main]
 async fn main() -> Result<()> {
-
-    let nyc_taxi_path = "/mnt/nyctaxi/parquet/year=2019";
-    let executor_host = "localhost";
-    let executor_port = 50051;
-
-    let ctx = Context::remote(executor_host, executor_port, HashMap::new());
+    
+    let ctx = Context::remote("localhost", 50051, HashMap::new());
 
     let results = ctx
-        .read_parquet(nyc_taxi_path, None)?
+        .read_parquet("/path/to/data", None)?
         .aggregate(vec![col("passenger_count")], vec![max(col("fare_amount"))])?
         .collect()
         .await?;
@@ -76,47 +74,27 @@ async fn main() -> Result<()> {
 
 ## Status
 
-Distributed execution using async Rust has now been proven and we are working towards a 0.3.0 release in August 2020 
-that will support the following capabilities.
-
-### Operators:
-
-- Projection
-- Selection
-- Hash Aggregate
-- Limit
-
-### Expressions:
-
-- Basic aggregate expressions (`MIN`, `MAX`, `SUM`, `COUNT`, `AVG`)
-- Boolean expressions (`AND`, `OR`, `NOT`)
-- Comparison expressions (`==`, `!=`, `<=`, `<`, `>`, `>=`)
-- Basic math expressions (`+`, `-`, `*`, `/`, `%`)
-- Rust user-defined functions (UDFs)
-- Java user-defined functions (UDFs)
-
-### File Formats:
-
-- CSV
-- Parquet
+Ballista is now available! Please refer to the [user guide](https://ballistacompute.org/docs/) for instructions on using 
+released versions of Ballista. 
 
 ## Roadmap
 
-After the 0.3.0 release we will start working on more complex operators, particularly joins, using the TPCH
+We are now working on support for more complex operators, particularly joins, using the TPCH
 benchmarks to drive requirements. The full roadmap is available [here](https://github.com/ballista-compute/ballista/milestones?direction=asc&sort=title&state=open).
 
 ## More Examples
 
 The following examples should help illustrate the current capabilities of Ballista
 
-- [Distributed query execution in Rust](https://github.com/ballista-compute/ballista/tree/main/rust/examples/distributed-query)
 - [TPC-H Benchmark](https://github.com/ballista-compute/ballista/tree/main/rust/examples/tpch)
+- [Distributed query execution in Rust](https://github.com/ballista-compute/ballista/tree/main/rust/examples/distributed-query)
 - [Rust bindings for Apache Spark](https://github.com/ballista-compute/ballista/tree/main/rust/examples/apache-spark-rust-bindings)
 
 ## Documentation
 
-The [user guide](https://ballistacompute.org/docs/) is hosted at [https://ballistacompute.org](https://ballistacompute.org/), along with the [blog](https://ballistacompute.org/) where 
-news and release notes are posted.
+The [user guide](https://ballistacompute.org/docs/) is hosted at [https://ballistacompute.org](https://ballistacompute.org/), 
+along with the [blog](https://ballistacompute.org/) where news and release notes are posted.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for information on contributing to this project.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ async fn main() -> Result<()> {
 
 ## Status
 
-Ballista is now available! Please refer to the [user guide](https://ballistacompute.org/docs/) for instructions on using 
-released versions of Ballista. 
+An alpha release of Ballista is now available, and we are working towards the full 0.3.0 release in August 2020. Please 
+refer to the [user guide](https://ballistacompute.org/docs/) for instructions on using a released versions of Ballista. 
 
 ## Roadmap
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 edition = "2018"
 

--- a/dev/build-jvm.sh
+++ b/dev/build-jvm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BALLISTA_VERSION=0.3.0-SNAPSHOT
+BALLISTA_VERSION=0.3.0-alpha-1
 
 set -e
 

--- a/dev/build-rust-base.sh
+++ b/dev/build-rust-base.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-BALLISTA_VERSION=0.3.0-SNAPSHOT
+BALLISTA_VERSION=0.3.0-alpha-1
 docker build -t ballistacompute/rust-base:$BALLISTA_VERSION -f docker/rust-base.dockerfile .

--- a/dev/build-rust-cached-deps.sh
+++ b/dev/build-rust-cached-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-BALLISTA_VERSION=0.3.0-SNAPSHOT
+BALLISTA_VERSION=0.3.0-alpha-1
 docker build -t ballistacompute/rust-cached-deps:$BALLISTA_VERSION -f docker/rust-cached-deps.dockerfile .

--- a/dev/build-rust.sh
+++ b/dev/build-rust.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BALLISTA_VERSION=0.3.0-SNAPSHOT
+BALLISTA_VERSION=0.3.0-alpha-1
 
 set -e
 

--- a/dev/build-spark.sh
+++ b/dev/build-spark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BALLISTA_VERSION=0.3.0-SNAPSHOT
+BALLISTA_VERSION=0.3.0-alpha-1
 
 set -e
 

--- a/dev/bump-version.sh
+++ b/dev/bump-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OLD_VERSION=0.2.6-SNAPSHOT
-NEW_VERSION=0.3.0-SNAPSHOT
+NEW_VERSION=0.3.0-alpha-1
 
 set -e
 

--- a/dev/publish-docker-images.sh
+++ b/dev/publish-docker-images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BALLISTA_VERSION=0.3.0-SNAPSHOT
+BALLISTA_VERSION=0.3.0-alpha-1
 
 set -e
 

--- a/docker/rust-cached-deps.dockerfile
+++ b/docker/rust-cached-deps.dockerfile
@@ -1,5 +1,5 @@
 # Base image extends rust:nightly which extends debian:buster-slim
-FROM ballistacompute/rust-base:0.3.0-alpha-0 as build
+FROM ballistacompute/rust-base:0.3.0-alpha-1 as build
 
 # Fetch Ballista dependencies
 WORKDIR /tmp

--- a/docker/rust-executor.dockerfile
+++ b/docker/rust-executor.dockerfile
@@ -1,5 +1,5 @@
 # Base image extends rust:nightly which extends debian:buster-slim
-FROM ballistacompute/rust-cached-deps:0.3.0-alpha-0 as build
+FROM ballistacompute/rust-cached-deps:0.3.0-alpha-1 as build
 
 # protobuf
 COPY proto/ballista.proto /tmp/ballista/proto/

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -6,20 +6,20 @@ services:
     ports:
       - "2379:2379"
   ballista-rust:
-    image: ballistacompute/ballista-rust:0.3.0-SNAPSHOT
+    image: ballistacompute/ballista-rust:0.3.0-alpha-1
     command: "/executor --mode etcd --etcd-urls etcd:2379 --external-host 0.0.0.0 --port 50051"
     ports:
       - "50051:50051"
     volumes:
       - /mnt/nyctaxi:/mnt/nyctaxi
   ballista-jvm:
-    image: ballistacompute/ballista-jvm:0.3.0-SNAPSHOT
+    image: ballistacompute/ballista-jvm:0.3.0-alpha-1
     ports:
       - "50052:50051"
     volumes:
       - /mnt/nyctaxi:/mnt/nyctaxi
   ballista-spark:
-    image: ballistacompute/ballista-spark:0.3.0-SNAPSHOT
+    image: ballistacompute/ballista-spark:0.3.0-alpha-1
     ports:
       - "50053:50051"
     volumes:

--- a/integration-tests/rust/Cargo.lock
+++ b/integration-tests/rust/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "ballista-integration-tests"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "ballista",
  "tokio 0.2.21",

--- a/integration-tests/rust/Cargo.toml
+++ b/integration-tests/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ballista-integration-tests"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 edition = "2018"
 

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "org.ballistacompute"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 
 allprojects {
     repositories {

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -176,7 +176,7 @@ spec:
     spec:
       containers:
       - name: ballista
-        image: ballistacompute/ballista-rust:0.3.0-SNAPSHOT
+        image: ballistacompute/ballista-rust:0.3.0-alpha-1
         resources:
           requests:
             cpu: "1"

--- a/kubernetes/ballista-cluster-jvm.yaml
+++ b/kubernetes/ballista-cluster-jvm.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ballista
-        image: ballistacompute/ballista-jvm:0.3.0-SNAPSHOT
+        image: ballistacompute/ballista-jvm:0.3.0-alpha-1
         resources:
           requests:
             cpu: "1"

--- a/kubernetes/ballista-cluster-rust.yaml
+++ b/kubernetes/ballista-cluster-rust.yaml
@@ -30,9 +30,9 @@ spec:
     spec:
       containers:
       - name: ballista
-        image: ballistacompute/ballista-rust:0.3.0-SNAPSHOT
+        image: ballistacompute/ballista-rust:0.3.0-alpha-1
         command: ["/executor"]
-        args: ["--mode=k8s", "--external-host=0.0.0.0", "--port=50051", "--concurrent-tasks=2"]
+        args: ["--mode=k8s", "--external-host=0.0.0.0", "--port=50051", "--concurrent-tasks=3"]
         resources:
           requests:
             cpu: "1"

--- a/kubernetes/ballista-cluster-rust.yaml
+++ b/kubernetes/ballista-cluster-rust.yaml
@@ -18,7 +18,7 @@ metadata:
   name: ballista
 spec:
   serviceName: "ballista"
-  replicas: 12
+  replicas: 6
   selector:
     matchLabels:
       app: ballista

--- a/kubernetes/ballista-cluster-rust.yaml
+++ b/kubernetes/ballista-cluster-rust.yaml
@@ -32,14 +32,14 @@ spec:
       - name: ballista
         image: ballistacompute/ballista-rust:0.3.0-SNAPSHOT
         command: ["/executor"]
-        args: ["--mode=k8s", "--external-host=0.0.0.0", "--port=50051"]
+        args: ["--mode=k8s", "--external-host=0.0.0.0", "--port=50051", "--concurrent-tasks=2"]
         resources:
           requests:
             cpu: "1"
-            memory: "1024Mi"
+            memory: "2024Mi"
           limits:
             cpu: "2"
-            memory: "2048Mi"
+            memory: "4048Mi"
         ports:
           - containerPort: 50051
             name: flight

--- a/kubernetes/ballista-cluster-rust.yaml
+++ b/kubernetes/ballista-cluster-rust.yaml
@@ -18,7 +18,7 @@ metadata:
   name: ballista
 spec:
   serviceName: "ballista"
-  replicas: 6
+  replicas: 12
   selector:
     matchLabels:
       app: ballista
@@ -36,10 +36,10 @@ spec:
         resources:
           requests:
             cpu: "1"
-            memory: "2024Mi"
+            memory: "1024Mi"
           limits:
             cpu: "2"
-            memory: "4048Mi"
+            memory: "2048Mi"
         ports:
           - containerPort: 50051
             name: flight

--- a/kubernetes/ballista-cluster-spark.yaml
+++ b/kubernetes/ballista-cluster-spark.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ballista
-        image: ballistacompute/ballista-spark:0.3.0-SNAPSHOT
+        image: ballistacompute/ballista-spark:0.3.0-alpha-1
         resources:
           requests:
             cpu: "1"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -700,7 +700,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "distributed-query"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "ballista",
  "structopt",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "spark-rust-bindings"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "ballista",
  "tokio 0.2.21",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "tpch"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "ballista",
  "tokio 0.2.21",

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ballista"
 description = "Distributed compute platform based on Apache Arrow"
 license = "Apache-2.0"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 homepage = "https://github.com/ballista-compute/ballista"
 repository = "https://github.com/ballista-compute/ballista"
 authors = ["Andy Grove <andygrove73@gmail.com>"]

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -31,7 +31,6 @@ async-trait = "0.1.36"
 random-fast-rng = "0.1.1"
 structopt = "0.3"
 etcd-client = "0.5"
-atomic_counter = "1.0.1"
 
 # Ballista 0.3.x releases depend on the officla Arrow 1.0.0 release
 arrow = "1.0.0"

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -31,6 +31,7 @@ async-trait = "0.1.36"
 random-fast-rng = "0.1.1"
 structopt = "0.3"
 etcd-client = "0.5"
+atomic_counter = "1.0.1"
 
 # Ballista 0.3.x releases depend on the officla Arrow 1.0.0 release
 arrow = "1.0.0"

--- a/rust/ballista/src/bin/executor.rs
+++ b/rust/ballista/src/bin/executor.rs
@@ -45,6 +45,10 @@ struct Opt {
     /// bind port
     #[structopt(short, long)]
     port: usize,
+
+    /// max concurrent tasks
+    #[structopt(short, long)]
+    concurrent_tasks: usize,
 }
 
 #[tokio::main]
@@ -72,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("{}:{}", bind_host, port);
     let addr = addr.parse()?;
     let executor: Arc<dyn Executor> = Arc::new(BallistaExecutor::new(config));
-    let service = BallistaFlightService::new(executor);
+    let service = BallistaFlightService::new(executor, opt.concurrent_tasks);
     let server = FlightServiceServer::new(service);
     println!(
         "Ballista v{} Rust Executor listening on {:?}",

--- a/rust/ballista/src/distributed/client.rs
+++ b/rust/ballista/src/distributed/client.rs
@@ -36,11 +36,12 @@ pub async fn execute_action(
     //TODO need to avoid connecting per request
 
     let addr = format!("http://{}:{}", host, port);
-    println!("Connecting to flight server at {}", addr);
+
+    //println!("Connecting to flight server at {}", addr);
+
     let mut client = FlightServiceClient::connect(addr)
         .await
         .map_err(|e| BallistaError::General(format!("{:?}", e)))?;
-    println!("connected ok");
 
     let serialized_action: protobuf::Action = action.try_into()?;
     let mut buf: Vec<u8> = Vec::with_capacity(serialized_action.encoded_len());

--- a/rust/ballista/src/distributed/executor.rs
+++ b/rust/ballista/src/distributed/executor.rs
@@ -236,7 +236,10 @@ impl Executor for BallistaExecutor {
             .expect("failed to lock mutex");
         match shuffle_partitions.remove(&key) {
             Some(partition) => Ok(partition),
-            _ => Err(ballista_error("invalid shuffle partition id")),
+            _ => Err(ballista_error(&format!(
+                "invalid shuffle partition id {}",
+                key
+            ))),
         }
     }
 

--- a/rust/ballista/src/distributed/flight_service.rs
+++ b/rust/ballista/src/distributed/flight_service.rs
@@ -76,14 +76,14 @@ pub struct BallistaFlightService {
 }
 
 impl BallistaFlightService {
-    pub fn new(executor: Arc<dyn Executor>) -> Self {
+    pub fn new(executor: Arc<dyn Executor>, max_concurrency: usize) -> Self {
         Self {
             executor,
             results_cache: Arc::new(Mutex::new(HashMap::new())),
             task_status_map: Arc::new(Mutex::new(HashMap::new())),
             concurrent_tasks: Arc::new(Mutex::new(ConcurrencyGuard {
                 concurrency_level: 0,
-                max_concurrency: 6, // TODO get from config
+                max_concurrency,
             })),
         }
     }

--- a/rust/ballista/src/distributed/flight_service.rs
+++ b/rust/ballista/src/distributed/flight_service.rs
@@ -80,9 +80,13 @@ impl FlightService for BallistaFlightService {
         println!("do_get: {:?}", action);
         match &action {
             physical_plan::Action::Execute(task) => {
+
+                // TODO get from config
+                let max_concurrent_tasks = 4;
+
                 {
                     let mut counter = self.concurrent_tasks.lock().unwrap();
-                    if counter.counter > 4 {
+                    if counter.counter > max_concurrent_tasks {
                         return Err(Status::resource_exhausted("too many concurrent tasks"));
                     }
                     counter.counter += 1;

--- a/rust/ballista/src/distributed/scheduler.rs
+++ b/rust/ballista/src/distributed/scheduler.rs
@@ -303,6 +303,7 @@ pub async fn execute_job(job: &Job, ctx: Arc<dyn ExecutionContext>) -> Result<Ve
                         // build queue of tasks per executor
                         let mut next_executor_id = 0;
                         let mut executor_tasks = HashMap::new();
+                        #[allow(clippy::needless_range_loop)]
                         for i in 0..executors.len() {
                             executor_tasks.insert(executors[i].id.clone(), vec![]);
                         }
@@ -330,6 +331,8 @@ pub async fn execute_job(job: &Job, ctx: Arc<dyn ExecutionContext>) -> Result<Ve
                         }
 
                         let mut threads = vec![];
+
+                        #[allow(clippy::needless_range_loop)]
                         for i in 0..executors.len() {
                             let executor = executors[i].clone();
                             let queue = executor_tasks
@@ -400,7 +403,7 @@ pub async fn execute_job(job: &Job, ctx: Arc<dyn ExecutionContext>) -> Result<Ve
                                                     {
                                                         Ok(shuffle_id) => {
                                                             println!("Task {} completed", task_key);
-                                                            shuffle_ids.push(shuffle_id.clone());
+                                                            shuffle_ids.push(shuffle_id);
                                                             task_status[i] = TaskStatus::Completed(shuffle_id)
                                                         }
                                                         Err(e) => {
@@ -448,7 +451,7 @@ pub async fn execute_job(job: &Job, ctx: Arc<dyn ExecutionContext>) -> Result<Ve
                                     .iter()
                                     .find(|e| e.id == executor_shuffle_ids.executor_id)
                                     .unwrap();
-                                shuffle_location_map.insert(shuffle_id.clone(), executor.clone());
+                                shuffle_location_map.insert(*shuffle_id, executor.clone());
                             }
                         }
                         stage_status_map.insert(stage.id, StageStatus::Completed);
@@ -462,7 +465,7 @@ pub async fn execute_job(job: &Job, ctx: Arc<dyn ExecutionContext>) -> Result<Ve
 
                             println!("stage final shuffle ids: {:?}", stage_shuffle_ids);
 
-                            if stage_shuffle_ids.len() > 0 {
+                            if !stage_shuffle_ids.is_empty() {
                                 let final_shuffle_ids = &stage_shuffle_ids[0]; //TODO Can't assume first one
                                 let final_shuffle_ids = &final_shuffle_ids.shuffle_ids;
                                 if final_shuffle_ids.len() == 1 {

--- a/rust/ballista/src/distributed/scheduler.rs
+++ b/rust/ballista/src/distributed/scheduler.rs
@@ -305,11 +305,8 @@ pub async fn execute_job(job: &Job, ctx: Arc<dyn ExecutionContext>) -> Result<Ve
 
                             let ctx = ctx.clone();
                             let handle = thread::spawn(move || {
-                                println!("in thread");
                                 smol::run(async {
-                                    println!("in smol::run");
                                     Task::blocking(async move {
-                                        println!("in Task::blocking");
                                         ctx.execute_task(executor_id.clone(), task).await
                                     })
                                     .await

--- a/rust/ballista/src/execution/operators/hash_aggregate.rs
+++ b/rust/ballista/src/execution/operators/hash_aggregate.rs
@@ -472,7 +472,9 @@ impl HashAggregateIter {
 
         let mode = mode.clone();
         let _ = std::thread::spawn(move || {
-            run(tx, &mode, input, group_expr, aggr_expr).unwrap();
+            if let Err(e) = run(tx, &mode, input, group_expr, aggr_expr) {
+                println!("HashAggregateExec thread terminated with error: {:?}", e);
+            }
         });
 
         Self {

--- a/rust/examples/apache-spark-rust-bindings/Cargo.toml
+++ b/rust/examples/apache-spark-rust-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spark-rust-bindings"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 edition = "2018"
 

--- a/rust/examples/distributed-query/Cargo.toml
+++ b/rust/examples/distributed-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distributed-query"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 edition = "2018"
 

--- a/rust/examples/tpch/Cargo.lock
+++ b/rust/examples/tpch/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "ballista"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "tpch"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 dependencies = [
  "ballista",
  "tokio 0.2.21",

--- a/rust/examples/tpch/Cargo.toml
+++ b/rust/examples/tpch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tpch"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 authors = ["Andy Grove <andygrove73@gmail.com>"]
 edition = "2018"
 

--- a/rust/examples/tpch/docker-compose.yaml
+++ b/rust/examples/tpch/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "2379:2379"
   ballista-rust:
-    image: ballistacompute/ballista-rust:0.3.0-SNAPSHOT
+    image: ballistacompute/ballista-rust:0.3.0-alpha-1
     command: "/executor --mode etcd --etcd-urls etcd:2379 --external-host 0.0.0.0 --port 50051"
     ports:
       - "50051:50051"

--- a/rust/examples/tpch/src/main.rs
+++ b/rust/examples/tpch/src/main.rs
@@ -26,7 +26,7 @@ use ballista::error::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     //TODO use command-line args
-    let path = "/mnt/tpch/parquet/10-24/lineitem";
+    let path = "/mnt/tpch/parquet/100-240/lineitem";
     let executor_host = "localhost";
     let executor_port = 50051;
     let query_no = 1;

--- a/spark/benchmarks/README.md
+++ b/spark/benchmarks/README.md
@@ -15,7 +15,7 @@ Relies on rbac and pv from top-level kubernetes dir in this repo
 ## Build Docker Image
 
 ```bash
-docker build -t ballistacompute/spark-benchmarks:0.3.0-SNAPSHOT .
+docker build -t ballistacompute/spark-benchmarks:0.3.0-alpha-1 .
 ```
 
 ## Deploy

--- a/spark/benchmarks/run-tpch-k8s.sh
+++ b/spark/benchmarks/run-tpch-k8s.sh
@@ -8,5 +8,5 @@ $SPARK_HOME/bin/spark-submit \
     --conf spark.kubernetes.driver.podTemplateFile=pod-template.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=pod-template.yaml \
     --conf spark.executor.instances=12 \
-    --conf spark.kubernetes.container.image=ballistacompute/spark-benchmarks:0.3.0-SNAPSHOT \
+    --conf spark.kubernetes.container.image=ballistacompute/spark-benchmarks:0.3.0-alpha-1 \
     local:////opt/ballista/jars/benchmarks.jar

--- a/spark/benchmarks/run-tpch-k8s.sh
+++ b/spark/benchmarks/run-tpch-k8s.sh
@@ -7,6 +7,6 @@ $SPARK_HOME/bin/spark-submit \
     --class org.ballistacompute.spark.benchmarks.tpch.Tpch \
     --conf spark.kubernetes.driver.podTemplateFile=pod-template.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=pod-template.yaml \
-    --conf spark.executor.instances=2 \
+    --conf spark.executor.instances=12 \
     --conf spark.kubernetes.container.image=ballistacompute/spark-benchmarks:0.3.0-SNAPSHOT \
     local:////opt/ballista/jars/benchmarks.jar

--- a/spark/benchmarks/src/main/scala/org/ballistacompute/spark/benchmarks/tpch/Tpch.scala
+++ b/spark/benchmarks/src/main/scala/org/ballistacompute/spark/benchmarks/tpch/Tpch.scala
@@ -60,7 +60,7 @@ object Tpch {
 
     spark.time {
 
-      spark.read.parquet("/mnt/tpch/parquet/10-24/lineitem").createOrReplaceTempView("lineitem")
+      spark.read.parquet("/mnt/tpch/parquet/100-240/lineitem").createOrReplaceTempView("lineitem")
 
       val df = spark.sql(
         """

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.ballistacompute.spark"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0-alpha-1"
 description = "Ballista Spark Support"
 
 allprojects {
@@ -41,11 +41,11 @@ subprojects {
 
         // note that this project depends on the kotlin artifacts being published to a local maven repository
         // see ../jvm/README.md for instructions on publishing those artifacts
-        implementation("org.ballistacompute:datatypes:0.3.0-SNAPSHOT")
-        implementation("org.ballistacompute:datasource:0.3.0-SNAPSHOT")
-        implementation("org.ballistacompute:logical-plan:0.3.0-SNAPSHOT")
-        implementation("org.ballistacompute:protobuf:0.3.0-SNAPSHOT")
-        implementation("org.ballistacompute:executor:0.3.0-SNAPSHOT")
+        implementation("org.ballistacompute:datatypes:0.3.0-alpha-1")
+        implementation("org.ballistacompute:datasource:0.3.0-alpha-1")
+        implementation("org.ballistacompute:logical-plan:0.3.0-alpha-1")
+        implementation("org.ballistacompute:protobuf:0.3.0-alpha-1")
+        implementation("org.ballistacompute:executor:0.3.0-alpha-1")
 
         implementation("org.apache.arrow:flight-core:1.0.0")
         implementation("org.apache.arrow:flight-grpc:1.0.0")


### PR DESCRIPTION
Summary of changes:

- It is now possible to run TPCH query 1 using 100 scale factor (22 GB lineitem) but performance is bad
- Submitting a task to an executor is no longer a blocking call waiting for the task to complete. The executor spawns a thread to run the task and returns immediately.
- The scheduler polls executors for task completion and has better error handling.