### PR TITLE
Migrate to latest arrow

### DIFF
--- a/proto/ballista.proto
+++ b/proto/ballista.proto
@@ -17,9 +17,6 @@ message LogicalExprNode {
   string column_name = 10;
   bool has_column_name = 11;
 
-  uint32 column_index = 12;
-  bool has_column_index = 13;
-
   // alias
   AliasNode alias = 14;
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -84,9 +84,8 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "arrow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231fbfd6bcbf9eabccc95201f14071938e3288eff8b3aed8ef951b291b2bc7e"
+version = "1.1.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow#cd503c3f583dab4b94c9934d525664e5897ff06d"
 dependencies = [
  "arrow-flight",
  "chrono",
@@ -106,9 +105,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbc05937e9bd25ed444b1fbdaccd9ac199a8266fccbf898406e78cc5a318d59"
+version = "1.1.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow#cd503c3f583dab4b94c9934d525664e5897ff06d"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
@@ -624,9 +622,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac06e300fea276312cb230a744a24b60cf311a81fa1b963b6bb852e1f8d1eb"
+version = "1.1.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow#cd503c3f583dab4b94c9934d525664e5897ff06d"
 dependencies = [
  "arrow",
  "clap",
@@ -1738,9 +1735,8 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234036500c16044c0f7c96bcd77c6655762c7663264a4ef154c52eeab6235003"
+version = "1.1.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow#cd503c3f583dab4b94c9934d525664e5897ff06d"
 dependencies = [
  "arrow",
  "brotli",

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -32,17 +32,10 @@ random-fast-rng = "0.1.1"
 structopt = "0.3"
 etcd-client = "0.5"
 
-# Ballista 0.3.x releases depend on the officla Arrow 1.0.0 release
-arrow = "1.0.0"
-arrow-flight = "1.0.0"
-datafusion = "1.0.0"
-parquet = "1.0.0"
-
-# Ballista 0.4.0-SNAPSHOT depends on latest Arrow
-#arrow = { git = "https://github.com/apache/arrow" }
-#arrow-flight = { git = "https://github.com/apache/arrow" }
-#datafusion = { git = "https://github.com/apache/arrow" }
-#parquet = { git = "https://github.com/apache/arrow" }
+arrow = { git = "https://github.com/apache/arrow" }
+arrow-flight = { git = "https://github.com/apache/arrow" }
+datafusion = { git = "https://github.com/apache/arrow" }
+parquet = { git = "https://github.com/apache/arrow" }
 
 [[bin]]
 name = "executor"

--- a/rust/ballista/benches/hash_agg.rs
+++ b/rust/ballista/benches/hash_agg.rs
@@ -14,9 +14,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         Field::new("c1", DataType::Int32, false),
     ]);
     let batch = gen.create_batch(&schema, 1024).unwrap();
-    let array = batch.column(0);
+    let array = batch.column("c1");
 
-    let aggr_expr = sum(col(1, "c1"));
+    let aggr_expr = sum(col("c1"));
     let mut accum = aggr_expr.create_accumulator(&AggregateMode::Partial);
 
     c.bench_function("sum accum array", |b| b.iter(|| accum.accumulate(&array)));

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -17,9 +17,6 @@ message LogicalExprNode {
   string column_name = 10;
   bool has_column_name = 11;
 
-  uint32 column_index = 12;
-  bool has_column_index = 13;
-
   // alias
   AliasNode alias = 14;
 

--- a/rust/ballista/src/distributed/executor.rs
+++ b/rust/ballista/src/distributed/executor.rs
@@ -20,11 +20,8 @@ use std::thread;
 
 use crate::arrow::datatypes::Schema;
 use crate::arrow::record_batch::RecordBatch;
-use crate::datafusion;
 use crate::datafusion::execution::context::ExecutionContext as DFContext;
 use crate::datafusion::logicalplan::LogicalPlan;
-use crate::datafusion::logicalplan::{Expr, LogicalPlanBuilder};
-use crate::datafusion::optimizer::optimizer::OptimizerRule;
 use crate::distributed::client::execute_action;
 use crate::distributed::etcd::{etcd_get_executors, start_etcd_thread};
 use crate::distributed::k8s::k8s_get_executors;
@@ -244,10 +241,6 @@ impl Executor for BallistaExecutor {
         println!("Logical plan:\n{:?}", logical_plan);
         let ctx = DFContext::new();
 
-        // workaround for https://issues.apache.org/jira/browse/ARROW-9542
-        let mut rule = ResolveColumnsRule::new();
-        let logical_plan = rule.optimize(logical_plan)?;
-
         let logical_plan = ctx.optimize(&logical_plan)?;
         println!("Optimized logical plan:\n{:?}", logical_plan);
 
@@ -281,108 +274,5 @@ impl Executor for BallistaExecutor {
             Ok(handle) => handle,
             Err(e) => Err(ballista_error(&format!("Executor thread failed: {:?}", e))),
         }
-    }
-}
-
-/// Replace UnresolvedColumns with Columns
-pub struct ResolveColumnsRule {}
-
-impl ResolveColumnsRule {
-    #[allow(missing_docs)]
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for ResolveColumnsRule {
-    fn default() -> Self {
-        ResolveColumnsRule::new()
-    }
-}
-
-impl OptimizerRule for ResolveColumnsRule {
-    fn optimize(&mut self, plan: &LogicalPlan) -> datafusion::error::Result<LogicalPlan> {
-        match plan {
-            LogicalPlan::Projection { input, expr, .. } => {
-                Ok(LogicalPlanBuilder::from(&self.optimize(input)?)
-                    .project(rewrite_expr_list(expr, &input.schema())?)?
-                    .build()?)
-            }
-            LogicalPlan::Selection { expr, input } => {
-                Ok(LogicalPlanBuilder::from(&self.optimize(input)?)
-                    .filter(rewrite_expr(expr, &input.schema())?)?
-                    .build()?)
-            }
-            LogicalPlan::Aggregate {
-                input,
-                group_expr,
-                aggr_expr,
-                ..
-            } => Ok(LogicalPlanBuilder::from(&self.optimize(input)?)
-                .aggregate(
-                    rewrite_expr_list(group_expr, &input.schema())?,
-                    rewrite_expr_list(aggr_expr, &input.schema())?,
-                )?
-                .build()?),
-            LogicalPlan::Sort { input, expr, .. } => {
-                Ok(LogicalPlanBuilder::from(&self.optimize(input)?)
-                    .sort(rewrite_expr_list(expr, &input.schema())?)?
-                    .build()?)
-            }
-            _ => Ok(plan.clone()),
-        }
-    }
-}
-
-fn rewrite_expr_list(expr: &[Expr], schema: &Schema) -> datafusion::error::Result<Vec<Expr>> {
-    Ok(expr
-        .iter()
-        .map(|e| rewrite_expr(e, schema))
-        .collect::<datafusion::error::Result<Vec<_>>>()?)
-}
-
-fn rewrite_expr(expr: &Expr, schema: &Schema) -> datafusion::error::Result<Expr> {
-    match expr {
-        Expr::Alias(expr, alias) => Ok(rewrite_expr(&expr, schema)?.alias(&alias)),
-        Expr::BinaryExpr { left, op, right } => Ok(Expr::BinaryExpr {
-            left: Box::new(rewrite_expr(&left, schema)?),
-            op: op.clone(),
-            right: Box::new(rewrite_expr(&right, schema)?),
-        }),
-        Expr::Not(expr) => Ok(Expr::Not(Box::new(rewrite_expr(&expr, schema)?))),
-        Expr::IsNotNull(expr) => Ok(Expr::IsNotNull(Box::new(rewrite_expr(&expr, schema)?))),
-        Expr::IsNull(expr) => Ok(Expr::IsNull(Box::new(rewrite_expr(&expr, schema)?))),
-        Expr::Cast { expr, data_type } => Ok(Expr::Cast {
-            expr: Box::new(rewrite_expr(&expr, schema)?),
-            data_type: data_type.clone(),
-        }),
-        Expr::Sort {
-            expr,
-            asc,
-            nulls_first,
-        } => Ok(Expr::Sort {
-            expr: Box::new(rewrite_expr(&expr, schema)?),
-            asc: *asc,
-            nulls_first: *nulls_first,
-        }),
-        Expr::ScalarFunction {
-            name,
-            args,
-            return_type,
-        } => Ok(Expr::ScalarFunction {
-            name: name.clone(),
-            args: rewrite_expr_list(args, schema)?,
-            return_type: return_type.clone(),
-        }),
-        Expr::AggregateFunction {
-            name,
-            args,
-            return_type,
-        } => Ok(Expr::AggregateFunction {
-            name: name.clone(),
-            args: rewrite_expr_list(args, schema)?,
-            return_type: return_type.clone(),
-        }),
-        _ => Ok(expr.clone()),
     }
 }

--- a/rust/ballista/src/distributed/executor.rs
+++ b/rust/ballista/src/distributed/executor.rs
@@ -344,7 +344,6 @@ fn rewrite_expr_list(expr: &[Expr], schema: &Schema) -> datafusion::error::Resul
 fn rewrite_expr(expr: &Expr, schema: &Schema) -> datafusion::error::Result<Expr> {
     match expr {
         Expr::Alias(expr, alias) => Ok(rewrite_expr(&expr, schema)?.alias(&alias)),
-        Expr::UnresolvedColumn(name) => Ok(Expr::Column(schema.index_of(&name)?)),
         Expr::BinaryExpr { left, op, right } => Ok(Expr::BinaryExpr {
             left: Box::new(rewrite_expr(&left, schema)?),
             op: op.clone(),

--- a/rust/ballista/src/distributed/executor.rs
+++ b/rust/ballista/src/distributed/executor.rs
@@ -217,7 +217,7 @@ impl Executor for BallistaExecutor {
         shuffle_partitions.insert(
             key,
             ShufflePartition {
-                schema: stream.schema().as_ref().clone(),
+                schema: exec_plan.schema().as_ref().clone(),
                 data: batches,
             },
         );

--- a/rust/ballista/src/execution/expressions/alias.rs
+++ b/rust/ballista/src/execution/expressions/alias.rs
@@ -36,10 +36,6 @@ impl Alias {
 }
 
 impl Expression for Alias {
-    fn name(&self) -> String {
-        self.alias.clone()
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.expr.data_type(input_schema)
     }
@@ -73,10 +69,6 @@ impl AliasedAggregate {
 }
 
 impl AggregateExpr for AliasedAggregate {
-    fn name(&self) -> String {
-        self.alias.clone()
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.expr.data_type(input_schema)
     }

--- a/rust/ballista/src/execution/expressions/arithmetic.rs
+++ b/rust/ballista/src/execution/expressions/arithmetic.rs
@@ -46,10 +46,6 @@ pub fn add(l: Arc<dyn Expression>, r: Arc<dyn Expression>) -> Arc<dyn Expression
 }
 
 impl Expression for Add {
-    fn name(&self) -> String {
-        format!("{} + {}", self.l.name(), self.r.name())
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.l.data_type(input_schema)
     }
@@ -100,10 +96,6 @@ pub fn subtract(l: Arc<dyn Expression>, r: Arc<dyn Expression>) -> Arc<dyn Expre
 }
 
 impl Expression for Subtract {
-    fn name(&self) -> String {
-        format!("{} - {}", self.l.name(), self.r.name())
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.l.data_type(input_schema)
     }
@@ -156,10 +148,6 @@ pub fn mult(l: Arc<dyn Expression>, r: Arc<dyn Expression>) -> Arc<dyn Expressio
 }
 
 impl Expression for Multiply {
-    fn name(&self) -> String {
-        format!("{} * {}", self.l.name(), self.r.name())
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.l.data_type(input_schema)
     }
@@ -212,10 +200,6 @@ pub fn div(l: Arc<dyn Expression>, r: Arc<dyn Expression>) -> Arc<dyn Expression
 }
 
 impl Expression for Divide {
-    fn name(&self) -> String {
-        format!("{} / {}", self.l.name(), self.r.name())
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.l.data_type(input_schema)
     }

--- a/rust/ballista/src/execution/expressions/avg.rs
+++ b/rust/ballista/src/execution/expressions/avg.rs
@@ -36,10 +36,6 @@ impl Avg {
 }
 
 impl AggregateExpr for Avg {
-    fn name(&self) -> String {
-        format!("AVG({:?})", self.input)
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         match self.input.data_type(input_schema)? {
             DataType::Int8

--- a/rust/ballista/src/execution/expressions/column.rs
+++ b/rust/ballista/src/execution/expressions/column.rs
@@ -20,40 +20,34 @@ use crate::arrow::datatypes::{DataType, Schema};
 use crate::error::Result;
 use crate::execution::physical_plan::{ColumnarBatch, ColumnarValue, Expression};
 
-/// Reference to a column by index
+/// Reference to a column by name
 #[derive(Debug)]
 pub struct Column {
-    index: usize,
     name: String,
 }
 
 impl Column {
-    pub fn new(index: usize, name: &str) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            index,
             name: name.to_owned(),
         }
     }
 }
 
-pub fn col(index: usize, name: &str) -> Arc<dyn Expression> {
-    Arc::new(Column::new(index, name))
+pub fn col(name: &str) -> Arc<dyn Expression> {
+    Arc::new(Column::new(name))
 }
 
 impl Expression for Column {
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        Ok(input_schema.field(self.index).data_type().clone())
+        Ok(input_schema.field_with_name(&self.name)?.data_type().clone())
     }
 
     fn nullable(&self, input_schema: &Schema) -> Result<bool> {
-        Ok(input_schema.field(self.index).is_nullable())
+        Ok(input_schema.field_with_name(&self.name)?.is_nullable())
     }
 
     fn evaluate(&self, input: &ColumnarBatch) -> Result<ColumnarValue> {
-        Ok(input.column(self.index).clone())
+        Ok(input.column(&self.name)?.clone())
     }
 }

--- a/rust/ballista/src/execution/expressions/comparison.rs
+++ b/rust/ballista/src/execution/expressions/comparison.rs
@@ -64,10 +64,6 @@ macro_rules! compare_op {
 }
 
 impl Expression for Comparison {
-    fn name(&self) -> String {
-        format!("{:?} {:?} {:?}", self.l, self.op, self.r)
-    }
-
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::Boolean)
     }

--- a/rust/ballista/src/execution/expressions/count.rs
+++ b/rust/ballista/src/execution/expressions/count.rs
@@ -34,10 +34,6 @@ impl Count {
 }
 
 impl AggregateExpr for Count {
-    fn name(&self) -> String {
-        format!("COUNT({:?})", self.input)
-    }
-
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::UInt64)
     }

--- a/rust/ballista/src/execution/expressions/literal.rs
+++ b/rust/ballista/src/execution/expressions/literal.rs
@@ -31,10 +31,6 @@ impl Literal {
 }
 
 impl Expression for Literal {
-    fn name(&self) -> String {
-        format!("{:?}", self.value)
-    }
-
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         match &self.value {
             ScalarValue::UInt8(_) => Ok(DataType::UInt8),

--- a/rust/ballista/src/execution/expressions/max.rs
+++ b/rust/ballista/src/execution/expressions/max.rs
@@ -38,10 +38,6 @@ impl Max {
 }
 
 impl AggregateExpr for Max {
-    fn name(&self) -> String {
-        format!("MAX({:?})", self.expr)
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         match self.expr.data_type(input_schema)? {
             DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {

--- a/rust/ballista/src/execution/expressions/min.rs
+++ b/rust/ballista/src/execution/expressions/min.rs
@@ -38,10 +38,6 @@ impl Min {
 }
 
 impl AggregateExpr for Min {
-    fn name(&self) -> String {
-        format!("MIN({:?})", self.expr)
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         match self.expr.data_type(input_schema)? {
             DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {

--- a/rust/ballista/src/execution/expressions/sum.rs
+++ b/rust/ballista/src/execution/expressions/sum.rs
@@ -36,10 +36,6 @@ impl Sum {
 }
 
 impl AggregateExpr for Sum {
-    fn name(&self) -> String {
-        format!("SUM({:?})", self.input)
-    }
-
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         match self.input.data_type(input_schema)? {
             DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {

--- a/rust/ballista/src/execution/operators/filter.rs
+++ b/rust/ballista/src/execution/operators/filter.rs
@@ -101,10 +101,6 @@ struct FilterIter {
 
 #[async_trait]
 impl ColumnarBatchIter for FilterIter {
-    fn schema(&self) -> Arc<Schema> {
-        self.input.schema()
-    }
-
     async fn next(&self) -> Result<Option<ColumnarBatch>> {
         match self.input.next().await? {
             Some(input) => {

--- a/rust/ballista/src/execution/operators/filter.rs
+++ b/rust/ballista/src/execution/operators/filter.rs
@@ -32,6 +32,7 @@ use crate::{
 use crate::execution::physical_plan::Partitioning;
 use async_trait::async_trait;
 use std::time::Instant;
+use arrow::record_batch::RecordBatch;
 
 /// FilterExec evaluates a boolean expression against each row of input to determine which rows
 /// to include in output batches.
@@ -129,11 +130,10 @@ fn apply_filter(batch: &ColumnarBatch, bitmask: &ColumnarValue) -> Result<Column
     let predicate = cast_array!(predicate, BooleanArray)?;
 
     let mut filtered_arrays = Vec::with_capacity(batch.num_columns());
-    for i in 0..batch.num_columns() {
-        let array = batch.column(i);
+    for column in batch.schema().fields().iter().map(|f| f.name()) {
+        let array = batch.column(column)?;
         let filtered_array = arrow::compute::filter(array.to_arrow()?.as_ref(), predicate)?;
-        filtered_arrays.push(ColumnarValue::Columnar(filtered_array));
+        filtered_arrays.push(filtered_array);
     }
-
-    Ok(ColumnarBatch::from_values(&filtered_arrays))
+    Ok(ColumnarBatch::from_arrow(&RecordBatch::try_new(batch.schema(), filtered_arrays)?))
 }

--- a/rust/ballista/src/execution/operators/hash_aggregate.rs
+++ b/rust/ballista/src/execution/operators/hash_aggregate.rs
@@ -30,19 +30,21 @@ use crate::error::{ballista_error, BallistaError, Result};
 use crate::execution::physical_plan::{
     compile_aggregate_expressions, compile_expressions, Accumulator, AggregateExpr, AggregateMode,
     ColumnarBatch, ColumnarBatchIter, ColumnarBatchStream, ColumnarValue, Distribution,
-    ExecutionContext, ExecutionPlan, Expression, MaybeColumnarBatch, Partitioning, PhysicalPlan,
+    ExecutionContext, ExecutionPlan, Expression, MaybeColumnarBatch, Partitioning, PhysicalPlan, compile_expression, compile_aggregate_expression,
 };
 
 use async_trait::async_trait;
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use smol::Task;
 use std::collections::HashMap;
+use arrow::record_batch::RecordBatch;
 
 /// HashAggregateExec applies a hash aggregate operation against its input.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct HashAggregateExec {
     pub(crate) mode: AggregateMode,
+    // these are logical expressions because physical expressions
+    // are not serializable due to their dynamic nature
     pub(crate) group_expr: Vec<Expr>,
     pub(crate) aggr_expr: Vec<Expr>,
     pub(crate) child: Arc<PhysicalPlan>,
@@ -59,20 +61,23 @@ impl HashAggregateExec {
         //TODO should just use schema from logical plan rather than derive it here?
 
         let input_schema = child.as_execution_plan().schema();
-        let compiled_group_expr = compile_expressions(&group_expr, &input_schema)?;
-        let compiled_aggr_expr = compile_aggregate_expressions(&aggr_expr, &input_schema)?;
 
-        let mut fields = compiled_group_expr
-            .iter()
-            .map(|e| e.to_schema_field(&input_schema))
-            .collect::<Result<Vec<_>>>()?;
-        fields.extend(
-            compiled_aggr_expr
-                .iter()
-                .map(|e| e.to_schema_field(&input_schema))
-                .collect::<Result<Vec<_>>>()?,
-        );
+        // compile the logical expressions along with their name
+        let physical_group_expr: Vec<(Arc<dyn Expression>, String)> = group_expr.iter().map(|expr| {
+            Ok((compile_expression(expr, &child.as_execution_plan().schema())?, expr.name(&input_schema)?.clone()))
+        }).collect::<Result<Vec<_>>>()?;
+        let physical_aggr_expr: Vec<(Arc<dyn AggregateExpr>, String)> = aggr_expr.iter().map(|expr| {
+            Ok((compile_aggregate_expression(expr, &child.as_execution_plan().schema())?, expr.name(&input_schema)?.clone()))
+        }).collect::<Result<Vec<_>>>()?;
 
+        // build the output schema based on the physical expressions
+        let mut fields = Vec::with_capacity(physical_group_expr.len() + physical_aggr_expr.len());
+        for (expr, name) in &physical_group_expr {
+            fields.push(Field::new(name, expr.data_type(&input_schema)?, expr.nullable(&input_schema)?));
+        }
+        for (expr, name) in &physical_aggr_expr {
+            fields.push(Field::new(name, expr.data_type(&input_schema)?, expr.nullable(&input_schema)?));
+        }
         let schema = Arc::new(Schema::new(fields));
 
         Ok(Self {
@@ -128,29 +133,25 @@ impl ExecutionPlan for HashAggregateExec {
         let child_exec = self.child.as_execution_plan();
         let input_schema = child_exec.schema();
         let input = child_exec.execute(ctx.clone(), partition_index).await?;
+
         let group_expr = compile_expressions(&self.group_expr, &input_schema)?;
         let aggr_expr = compile_aggregate_expressions(&self.aggr_expr, &input_schema)?;
-        let a: Vec<Field> = group_expr
-            .iter()
-            .map(|e| e.to_schema_field(&input_schema))
-            .collect::<Result<_>>()?;
-        let b: Vec<Field> = aggr_expr
-            .iter()
-            .map(|e| e.to_schema_field(&input_schema))
-            .collect::<Result<_>>()?;
-        let mut fields = vec![];
-        for field in &a {
-            fields.push(field.clone());
+
+        let mut fields = Vec::with_capacity(group_expr.len() + aggr_expr.len());
+        for (i, expr) in group_expr.iter().enumerate() {
+            fields.push(Field::new(&self.group_expr[i].name(&input_schema)?, expr.data_type(&input_schema)?, expr.nullable(&input_schema)?))
         }
-        for field in &b {
-            fields.push(field.clone());
+        for (i, expr) in aggr_expr.iter().enumerate() {
+            fields.push(Field::new(&self.aggr_expr[i].name(&input_schema)?, expr.data_type(&input_schema)?, expr.nullable(&input_schema)?))
         }
+        let schema = Arc::new(Schema::new(fields));
+
         Ok(Arc::new(HashAggregateIter::new(
             &self.mode,
             input,
             group_expr,
             aggr_expr,
-            Arc::new(Schema::new(fields)),
+            schema,
         )))
     }
 }
@@ -241,13 +242,14 @@ fn run(
     input: ColumnarBatchStream,
     group_expr: Vec<Arc<dyn Expression>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
+    schema: &Schema,
 ) -> Result<()> {
     smol::run(async {
         // metrics
         let start = Instant::now();
         let mut read_batch_time = 0;
         let mut accum_batch_time = 0;
-        let mut batch_count = 0;
+        let mut batch_count: i32 = 0;
         let mut row_count = 0;
 
         // hash map of grouping values to accumulators
@@ -325,6 +327,7 @@ fn run(
             input.as_ref().schema().as_ref(),
             &group_expr,
             &aggr_expr,
+            schema,
         )?;
         let create_final_batch_time = prepare_final_batch_start.elapsed().as_millis();
 
@@ -470,9 +473,10 @@ impl HashAggregateIter {
     ) -> Self {
         let (tx, rx): (Sender<MaybeColumnarBatch>, Receiver<MaybeColumnarBatch>) = unbounded();
 
+        let a = output_schema.clone();
         let mode = mode.clone();
         let _ = std::thread::spawn(move || {
-            run(tx, &mode, input, group_expr, aggr_expr).unwrap();
+            run(tx, &mode, input, group_expr, aggr_expr, &a).unwrap();
         });
 
         Self {
@@ -546,6 +550,7 @@ fn create_batch_from_accum_map(
     input_schema: &Schema,
     group_expr: &[Arc<dyn Expression>],
     aggr_expr: &[Arc<dyn AggregateExpr>],
+    schema: &Schema,
 ) -> Result<ColumnarBatch> {
     // build the result arrays
     let mut arrays: Vec<ArrayRef> = Vec::with_capacity(group_expr.len() + aggr_expr.len());
@@ -604,12 +609,7 @@ fn create_batch_from_accum_map(
         arrays.push(array?);
     }
 
-    let values: Vec<ColumnarValue> = arrays
-        .iter()
-        .map(|a| ColumnarValue::Columnar(a.clone()))
-        .collect();
-
-    Ok(ColumnarBatch::from_values(&values))
+    Ok(ColumnarBatch::from_arrow(&RecordBatch::try_new(Arc::new(schema.clone()), arrays)?))
 }
 
 #[async_trait]

--- a/rust/ballista/src/execution/operators/in_memory.rs
+++ b/rust/ballista/src/execution/operators/in_memory.rs
@@ -72,10 +72,6 @@ impl InMemoryTableScanIter {
 
 #[async_trait]
 impl ColumnarBatchIter for InMemoryTableScanIter {
-    fn schema(&self) -> Arc<Schema> {
-        self.data[0].schema()
-    }
-
     async fn next(&self) -> Result<Option<ColumnarBatch>> {
         let index = self.index.load(Ordering::SeqCst);
         if index < self.data.len() {

--- a/rust/ballista/src/execution/operators/projection.rs
+++ b/rust/ballista/src/execution/operators/projection.rs
@@ -20,11 +20,12 @@ use crate::arrow::datatypes::Schema;
 use crate::datafusion::logicalplan::Expr;
 use crate::error::Result;
 use crate::execution::physical_plan::{
-    compile_expressions, ColumnarBatch, ColumnarBatchIter, ColumnarBatchStream, ColumnarValue,
-    ExecutionContext, ExecutionPlan, Expression, Partitioning, PhysicalPlan,
+    ColumnarBatch, ColumnarBatchIter, ColumnarBatchStream,
+    ExecutionContext, ExecutionPlan, Expression, Partitioning, PhysicalPlan, compile_expression,
 };
 
 use async_trait::async_trait;
+use arrow::datatypes::Field;
 
 /// Projection operator evaluates expressions against an input.
 #[derive(Debug, Clone)]
@@ -39,19 +40,27 @@ pub struct ProjectionExec {
 
 impl ProjectionExec {
     pub fn try_new(expr: &[Expr], child: Arc<PhysicalPlan>) -> Result<Self> {
-        let exprs = compile_expressions(&expr, &child.as_execution_plan().schema())?;
-
         let input_schema = child.as_execution_plan().schema();
+
+        let exprs: Vec<(Arc<dyn Expression>, String)> = expr.iter().map(|expr| {
+            Ok((compile_expression(expr, &child.as_execution_plan().schema())?, expr.name(&input_schema)?.clone()))
+        }).collect::<Result<Vec<_>>>()?;
 
         let fields: Result<Vec<_>> = exprs
             .iter()
-            .map(|e| e.to_schema_field(&input_schema))
+            .map(|(expr, name)| {
+                Ok(Field::new(
+                    name,
+                    expr.data_type(&input_schema)?,
+                    expr.nullable(&input_schema)?,
+                ))
+            })
             .collect();
 
         let schema = Arc::new(Schema::new(fields?));
 
         Ok(Self {
-            exprs,
+            exprs: exprs.iter().map(|e| e.0.clone()).collect(),
             child,
             schema,
         })
@@ -84,6 +93,7 @@ impl ExecutionPlan for ProjectionExec {
                 .execute(ctx.clone(), partition_index)
                 .await?,
             projection: self.exprs.clone(),
+            schema: self.schema.clone(),
         }))
     }
 }
@@ -92,23 +102,24 @@ impl ExecutionPlan for ProjectionExec {
 struct ProjectionIter {
     input: ColumnarBatchStream,
     projection: Vec<Arc<dyn Expression>>,
+    schema: Arc<Schema>,
 }
 
 #[async_trait]
 impl ColumnarBatchIter for ProjectionIter {
     fn schema(&self) -> Arc<Schema> {
-        unimplemented!()
+        self.schema.clone()
     }
 
     async fn next(&self) -> Result<Option<ColumnarBatch>> {
         match self.input.next().await? {
             Some(batch) => {
-                let projected_values: Vec<ColumnarValue> = self
+                let projected_values = self
                     .projection
                     .iter()
                     .map(|e| e.evaluate(&batch))
                     .collect::<Result<Vec<_>>>()?;
-                Ok(Some(ColumnarBatch::from_values(&projected_values)))
+                Ok(Some(ColumnarBatch::from_values(&projected_values, self.schema().as_ref())))
             }
             None => Ok(None),
         }

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -62,9 +62,6 @@ pub struct ExecutorMeta {
 /// Async iterator over a stream of columnar batches
 #[async_trait]
 pub trait ColumnarBatchIter: Sync + Send {
-    /// Get the schema for the batches produced by this iterator.
-    fn schema(&self) -> Arc<Schema>;
-
     /// Get the next batch from the stream, or None if the stream has ended
     async fn next(&self) -> Result<Option<ColumnarBatch>>;
 

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -23,13 +23,13 @@
 //! The physical plan also accounts for partitioning and ordering of data between operators.
 
 use std::fmt::{self, Debug};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::arrow::array::{
     ArrayRef, Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder,
     Int8Builder, StringBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
-use crate::arrow::datatypes::{DataType, Field, Schema};
+use crate::arrow::datatypes::{DataType, Schema};
 use crate::arrow::record_batch::RecordBatch;
 use crate::datafusion::logicalplan::Expr;
 use crate::datafusion::logicalplan::LogicalPlan;
@@ -126,28 +126,16 @@ pub trait ExecutionPlan: Send + Sync {
 }
 
 pub trait Expression: Send + Sync + Debug {
-    /// Get the name to use in a schema to represent the result of this expression
-    fn name(&self) -> String;
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
     /// Decide whether this expression is nullable, given the schema of the input
     fn nullable(&self, input_schema: &Schema) -> Result<bool>;
     /// Evaluate an expression against a ColumnarBatch to produce a scalar or columnar result.
     fn evaluate(&self, input: &ColumnarBatch) -> Result<ColumnarValue>;
-    /// Generate schema Field type for this expression
-    fn to_schema_field(&self, input_schema: &Schema) -> Result<Field> {
-        Ok(Field::new(
-            &self.name(),
-            self.data_type(input_schema)?,
-            self.nullable(input_schema)?,
-        ))
-    }
 }
 
 /// Aggregate expression that can be evaluated against a RecordBatch
 pub trait AggregateExpr: Send + Sync + Debug {
-    /// Get the name to use in a schema to represent the result of this expression
-    fn name(&self) -> String;
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
     /// Decide whether this expression is nullable, given the schema of the input
@@ -156,14 +144,6 @@ pub trait AggregateExpr: Send + Sync + Debug {
     fn evaluate_input(&self, batch: &ColumnarBatch) -> Result<ColumnarValue>;
     /// Create an accumulator for this aggregate expression
     fn create_accumulator(&self, mode: &AggregateMode) -> Box<dyn Accumulator>;
-    /// Generate schema Field type for this expression
-    fn to_schema_field(&self, input_schema: &Schema) -> Result<Field> {
-        Ok(Field::new(
-            &self.name(),
-            self.data_type(input_schema)?,
-            self.nullable(input_schema)?,
-        ))
-    }
 }
 
 /// Aggregate accumulator
@@ -192,7 +172,7 @@ pub type MaybeColumnarBatch = Result<Option<ColumnarBatch>>;
 #[derive(Debug, Clone)]
 pub struct ColumnarBatch {
     schema: Arc<Schema>,
-    columns: Vec<ColumnarValue>,
+    columns: HashMap<String, ColumnarValue>,
 }
 
 impl ColumnarBatch {
@@ -200,7 +180,9 @@ impl ColumnarBatch {
         let columns = batch
             .columns()
             .iter()
-            .map(|c| ColumnarValue::Columnar(c.clone()))
+            .enumerate()
+            .map(|(i, array)|
+                (batch.schema().field(i).name().clone(), ColumnarValue::Columnar(array.clone())))
             .collect();
         Self {
             schema: batch.schema(),
@@ -208,29 +190,26 @@ impl ColumnarBatch {
         }
     }
 
-    pub fn from_values(values: &[ColumnarValue]) -> Self {
-        let schema = Schema::new(
-            values
-                .iter()
-                .enumerate()
-                .map(|(i, value)| Field::new(&format!("c{}", i), value.data_type().clone(), true))
-                .collect(),
-        );
+    pub fn from_values(values: &[ColumnarValue], schema: &Schema) -> Self {
+        let columns = schema.fields().iter().enumerate().map(
+                |(i, f)| (f.name().clone(), values[i].clone())).collect();
         Self {
-            schema: Arc::new(schema),
-            columns: values.to_vec(),
+            schema: Arc::new(schema.clone()),
+            columns,
         }
     }
 
     pub fn to_arrow(&self) -> Result<RecordBatch> {
         let arrays = self
-            .columns
+            .schema().fields()
             .iter()
-            .map(|c| match c {
-                ColumnarValue::Columnar(array) => Ok(array.clone()),
-                ColumnarValue::Scalar(_, _) => {
-                    // note that this can be implemented easily if needed
-                    Err(ballista_error("Cannot convert scalar value to Arrow array"))
+            .map(|c| {
+                match self.column(c.name())? {
+                    ColumnarValue::Columnar(array) => Ok(array.clone()),
+                    ColumnarValue::Scalar(_, _) => {
+                        // note that this can be implemented easily if needed
+                        Err(ballista_error("Cannot convert scalar value to Arrow array"))
+                    }
                 }
             })
             .collect::<Result<Vec<_>>>()?;
@@ -246,11 +225,11 @@ impl ColumnarBatch {
     }
 
     pub fn num_rows(&self) -> usize {
-        self.columns[0].len()
+        self.columns[self.schema().field(0).name()].len()
     }
 
-    pub fn column(&self, index: usize) -> &ColumnarValue {
-        &self.columns[index]
+    pub fn column(&self, name: &str) -> Result<&ColumnarValue> {
+        Ok(&self.columns[name])
     }
 }
 
@@ -524,8 +503,7 @@ pub struct ShuffleLocation {}
 pub fn compile_expression(expr: &Expr, input: &Schema) -> Result<Arc<dyn Expression>> {
     match expr {
         Expr::Alias(expr, name) => Ok(alias(compile_expression(expr, input)?, name)),
-        Expr::Column(n) => Ok(col(*n, input.field(*n).name())),
-        Expr::UnresolvedColumn(name) => Ok(col(input.index_of(name)?, name)),
+        Expr::Column(name) => Ok(col(name)),
         Expr::Literal(value) => Ok(lit(value.to_owned())),
         Expr::BinaryExpr { left, op, right } => {
             let l = compile_expression(left, input)?;

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -201,7 +201,7 @@ impl ColumnarBatch {
 
     pub fn to_arrow(&self) -> Result<RecordBatch> {
         let arrays = self
-            .schema().fields()
+            .schema.fields()
             .iter()
             .map(|c| {
                 match self.column(c.name())? {
@@ -225,7 +225,7 @@ impl ColumnarBatch {
     }
 
     pub fn num_rows(&self) -> usize {
-        self.columns[self.schema().field(0).name()].len()
+        self.columns[self.schema.field(0).name()].len()
     }
 
     pub fn column(&self, name: &str) -> Result<&ColumnarValue> {

--- a/rust/ballista/src/serde/from_proto.rs
+++ b/rust/ballista/src/serde/from_proto.rs
@@ -144,10 +144,8 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
                 op: from_proto_binary_op(&binary_expr.op)?,
                 right: Box::new(parse_required_expr(&binary_expr.r)?),
             })
-        } else if self.has_column_index {
-            Ok(Expr::Column(self.column_index as usize))
         } else if self.has_column_name {
-            Ok(Expr::UnresolvedColumn(self.column_name.clone()))
+            Ok(Expr::Column(self.column_name.clone()))
         } else if self.has_literal_string {
             Ok(Expr::Literal(ScalarValue::Utf8(
                 self.literal_string.clone(),

--- a/rust/ballista/src/serde/mod.rs
+++ b/rust/ballista/src/serde/mod.rs
@@ -39,7 +39,7 @@ pub fn decode_protobuf(bytes: &[u8]) -> Result<Action, BallistaError> {
 mod tests {
     use crate::arrow::datatypes::{DataType, Field, Schema};
     use crate::datafusion::execution::physical_plan::csv::CsvReadOptions;
-    use crate::datafusion::logicalplan::{col, lit_str, Expr, LogicalPlanBuilder};
+    use crate::datafusion::logicalplan::{col, lit, Expr, LogicalPlanBuilder};
     use crate::error::Result;
     use crate::execution::physical_plan::Action;
     use crate::protobuf;
@@ -60,7 +60,7 @@ mod tests {
             CsvReadOptions::new().schema(&schema).has_header(true),
             None,
         )
-        .and_then(|plan| plan.filter(col("state").eq(&lit_str("CO"))))
+        .and_then(|plan| plan.filter(col("state").eq(&lit("CO"))))
         .and_then(|plan| plan.project(vec![col("id")]))
         .and_then(|plan| plan.build())
         .unwrap();

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -204,16 +204,10 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
 
     fn try_into(self) -> Result<protobuf::LogicalExprNode, Self::Error> {
         match self {
-            Expr::Column(index) => {
-                let mut expr = empty_expr_node();
-                expr.has_column_index = true;
-                expr.column_index = *index as u32;
-                Ok(expr)
-            }
-            Expr::UnresolvedColumn(name) => {
+            Expr::Column(name) => {
                 let mut expr = empty_expr_node();
                 expr.has_column_name = true;
-                expr.column_name = name.to_owned();
+                expr.column_name = name.clone();
                 Ok(expr)
             }
             Expr::Alias(expr, alias) => {
@@ -500,8 +494,6 @@ fn empty_expr_node() -> protobuf::LogicalExprNode {
         has_literal_u64: false,
         has_literal_f32: false,
         has_literal_f64: false,
-        column_index: 0,
-        has_column_index: false,
         binary_expr: None,
         aggregate_expr: None,
     }

--- a/rust/ballista/src/utils/datagen.rs
+++ b/rust/ballista/src/utils/datagen.rs
@@ -19,9 +19,10 @@ use std::sync::Arc;
 use crate::arrow::array::{self, ArrayRef};
 use crate::arrow::datatypes::{DataType, Schema};
 use crate::error::Result;
-use crate::execution::physical_plan::{ColumnarBatch, ColumnarValue};
+use crate::execution::physical_plan::ColumnarBatch;
 
 use random_fast_rng::{FastRng, Random};
+use arrow::record_batch::RecordBatch;
 
 /// Random data generator
 #[allow(dead_code)]
@@ -88,12 +89,7 @@ impl DataGen {
             .map(|f| self.create_array(f.data_type(), f.is_nullable(), len))
             .collect::<Result<Vec<_>>>()?;
 
-        let columns: Vec<ColumnarValue> = columns
-            .iter()
-            .map(|c| ColumnarValue::Columnar(c.clone()))
-            .collect();
-
-        Ok(ColumnarBatch::from_values(&columns))
+        Ok(ColumnarBatch::from_arrow(&RecordBatch::try_new(Arc::new(schema.clone()), columns)?))
     }
 }
 

--- a/rust/ballista/tests/query_execution.rs
+++ b/rust/ballista/tests/query_execution.rs
@@ -9,29 +9,52 @@ use ballista::distributed::executor::{DefaultContext, DiscoveryMode, ExecutorCon
 use ballista::execution::operators::FilterExec;
 use ballista::execution::operators::HashAggregateExec;
 use ballista::execution::operators::InMemoryTableScanExec;
-use ballista::execution::physical_plan::{AggregateMode, ColumnarBatchStream, PhysicalPlan};
-use ballista::utils::datagen::DataGen;
+use ballista::execution::physical_plan::{AggregateMode, ColumnarBatchStream, PhysicalPlan, ColumnarBatch};
+use ballista::error::Result;
+use ballista::utils::pretty::result_str;
 use std::collections::HashMap;
 use std::time::Instant;
+use arrow::{array::Int32Array, record_batch::RecordBatch};
+
+
+pub fn build_table_i32(
+    a: (&str, &Vec<i32>),
+    b: (&str, &Vec<i32>),
+    c: (&str, &Vec<i32>),
+) -> Result<(RecordBatch, Schema)> {
+    let schema = Schema::new(vec![
+        Field::new(a.0, DataType::Int32, false),
+        Field::new(b.0, DataType::Int32, false),
+        Field::new(c.0, DataType::Int32, false),
+    ]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema.clone()),
+        vec![
+            Arc::new(Int32Array::from(a.1.clone())),
+            Arc::new(Int32Array::from(b.1.clone())),
+            Arc::new(Int32Array::from(c.1.clone())),
+        ],
+    )?;
+    Ok((batch, schema))
+}
+
 
 async fn execute(use_filter: bool) {
     //TODO remove unwraps
+    let (batch, _) = build_table_i32(
+        ("c0", &vec![1, 1, 3]),
+        ("c1", &vec![1, 2, 3]),
+        ("c2", &vec![1, 2, 3]),
+    ).unwrap();
+    let batch = ColumnarBatch::from_arrow(&batch);
 
-    let mut gen = DataGen::default();
+    let batches = vec![batch.clone(), batch];
 
-    let schema = Schema::new(vec![
-        Field::new("c0", DataType::Int8, true),
-        Field::new("c1", DataType::Int32, false),
-    ]);
-    let batch = gen.create_batch(&schema, 1024).unwrap();
-
-    let mut child = PhysicalPlan::InMemoryTableScan(Arc::new(InMemoryTableScanExec::new(vec![
-        batch.clone(),
-        batch,
-    ])));
+    let mut child = PhysicalPlan::InMemoryTableScan(Arc::new(InMemoryTableScanExec::new(batches)));
 
     if use_filter {
-        // WHERE col(0) >= col(0), which must not affect the final result
+        // WHERE col(c0) >= col(c0), which must not affect the final result
         child = PhysicalPlan::Filter(Arc::new(FilterExec::new(
             &child,
             &col("c0").gt_eq(&col("c0")),
@@ -72,15 +95,24 @@ async fn execute(use_filter: bool) {
 
     let batch = &results[0];
 
-    assert_eq!(251, batch.num_rows());
+    assert_eq!(2, batch.num_rows());
     assert_eq!(6, batch.num_columns());
 
-    assert_eq!(batch.column("c0").unwrap().data_type(), &DataType::Int8);
+    assert_eq!(batch.column("c0").unwrap().data_type(), &DataType::Int32);
     assert_eq!(batch.column("max_c1").unwrap().data_type(), &DataType::Int64);
     assert_eq!(batch.column("MAX(c1)").unwrap().data_type(), &DataType::Int64);
     assert_eq!(batch.column("AVG(c1)").unwrap().data_type(), &DataType::Float64);
     assert_eq!(batch.column("SUM(c1)").unwrap().data_type(), &DataType::Int64);
     assert_eq!(batch.column("COUNT(c1)").unwrap().data_type(), &DataType::UInt64);
+
+    let result = batch.to_arrow().unwrap();
+
+    let r = result_str(&vec![result]).unwrap();
+
+    // there are two batches => sum and count double
+    let expected = vec!["1\t1\t2\t1.5\t6\t4", "3\t3\t3\t3.0\t6\t2"];
+
+    assert_eq!(r, expected);
 }
 
 #[test]


### PR DESCRIPTION
This migrates the code base to align with master from arrow.

Note that I have only validated that the tests pass, and assumed that this was a sufficient condition. However, looking at the tests themselves, this may not be sufficient.

This removes two columns from `ballista.proto`.
