### PR TITLE
Respect schema and projection parameters from client

### DIFF
--- a/jvm/logical-plan/src/test/kotlin/LogicalPlanTest.kt
+++ b/jvm/logical-plan/src/test/kotlin/LogicalPlanTest.kt
@@ -38,8 +38,8 @@ class LogicalPlanTest {
     val filterExpr = Eq(col("state"), LiteralString("CO"))
     val selection = Selection(scan, filterExpr)
     // create a plan to represent the projection (SELECT)
-    val projectionList = listOf(col("id"), col("first_name"), col("last_name"))
-    val plan = Projection(selection, projectionList)
+    val projectionColumns = ProjectionColumns(listOf(col("id"), col("first_name"), col("last_name")))
+    val plan = Projection(selection, projectionColumns)
 
     assertEquals(
         "Projection: #id, #first_name, #last_name\n" +

--- a/jvm/protobuf/src/main/kotlin/ProtobufDeserializer.kt
+++ b/jvm/protobuf/src/main/kotlin/ProtobufDeserializer.kt
@@ -25,7 +25,7 @@ class ProtobufDeserializer {
     return if (node.hasScan()) {
       val schema = fromProto(node.scan.schema)
       val ds = CsvDataSource(node.scan.path, schema, true, 1024)
-      Scan(node.scan.path, ds, node.scan.projectionList.asByteStringList().map { it.toString() })
+      Scan(node.scan.path, ds, node.scan.projection.columnsList.asByteStringList().map { it.toString() })
     } else if (node.hasSelection()) {
       Selection(fromProto(node.input), fromProto(node.selection.expr))
     } else if (node.hasProjection()) {

--- a/jvm/protobuf/src/main/kotlin/ProtobufSerializer.kt
+++ b/jvm/protobuf/src/main/kotlin/ProtobufSerializer.kt
@@ -29,11 +29,14 @@ class ProtobufSerializer {
         val ds = plan.dataSource
         when (ds) {
           is CsvDataSource -> {
+            val projectionColumns = ProjectionColumns.newBuilder()
+              .addAllColumns(plan.projection)
+              .build()
             LogicalPlanNode.newBuilder()
                 .setScan(
                     ScanNode.newBuilder()
                         .setPath(plan.path)
-                        .addAllProjection(plan.projection)
+                        .setProjection(projectionColumns)
                         .build())
                 .build()
           }

--- a/proto/ballista.proto
+++ b/proto/ballista.proto
@@ -89,10 +89,14 @@ message LogicalPlanNode {
   AggregateNode aggregate = 23;
 }
 
+message ProjectionColumns {
+  repeated string columns = 1;
+}
+
 //TODO break this out into separate CsvScanNode and ParquetScanNode
 message ScanNode {
   string path = 1;
-  repeated string projection = 2;
+  ProjectionColumns projection = 2;
   Schema schema = 3;
   string file_format = 4; // parquet or csv
   bool has_header = 5; // csv specific

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -89,10 +89,14 @@ message LogicalPlanNode {
   AggregateNode aggregate = 23;
 }
 
+message ProjectionColumns {
+  repeated string columns = 1;
+}
+
 //TODO break this out into separate CsvScanNode and ParquetScanNode
 message ScanNode {
   string path = 1;
-  repeated string projection = 2;
+  ProjectionColumns projection = 2;
   Schema schema = 3;
   string file_format = 4; // parquet or csv
   bool has_header = 5; // csv specific

--- a/rust/ballista/src/distributed/scheduler.rs
+++ b/rust/ballista/src/distributed/scheduler.rs
@@ -596,11 +596,13 @@ pub fn create_physical_plan(plan: &LogicalPlan) -> Result<Arc<PhysicalPlan>> {
             }
         }
         LogicalPlan::CsvScan {
-            path, projection, ..
+            path, schema, has_header, projection, ..
         } => {
             //TODO make batch size and other csv options configurable from the context
             let batch_size = 64 * 1024;
-            let options = CsvReadOptions::new();
+            let options = CsvReadOptions::new()
+                .schema(schema)
+                .has_header(*has_header);
             let exec = CsvScanExec::try_new(&path, options, projection.clone(), batch_size)?;
             Ok(Arc::new(PhysicalPlan::CsvScan(Arc::new(exec))))
         }

--- a/rust/ballista/src/execution/operators/csv_scan.rs
+++ b/rust/ballista/src/execution/operators/csv_scan.rs
@@ -41,7 +41,7 @@ pub struct CsvScanExec {
     /// Schema representing the CSV file
     schema: SchemaRef,
     /// Does the CSV file have a header?
-    has_header: bool,
+    pub(crate) has_header: bool,
     /// An optional column delimiter. Defaults to `b','`
     delimiter: Option<u8>,
     /// Optional projection for which columns to load
@@ -97,6 +97,10 @@ impl CsvScanExec {
             Some(options.schema_infer_max_records),
             options.has_header,
         )?)
+    }
+
+    pub fn original_schema(&self) -> SchemaRef {
+        self.schema.clone()
     }
 }
 

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -122,7 +122,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
 
                 node.scan = Some(protobuf::ScanNode {
                     path: path.to_owned(),
-                    projection: projection,
+                    projection,
                     schema: Some(schema),
                     has_header: *has_header,
                     file_format: "csv".to_owned(),
@@ -150,7 +150,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
 
                 node.scan = Some(protobuf::ScanNode {
                     path: path.to_owned(),
-                    projection: projection,
+                    projection,
                     schema: Some(schema),
                     has_header: false,
                     file_format: "parquet".to_owned(),

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -109,16 +109,20 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
             } => {
                 let mut node = empty_logical_plan_node();
 
-                let projected_field_names = match projection {
-                    Some(p) => p.iter().map(|i| schema.field(*i).name().clone()).collect(),
-                    _ => vec![],
-                };
+                let projection = projection.as_ref().map(|column_indices| {
+                    let columns: Vec<String> = column_indices.iter()
+                        .map(|i| schema.field(*i).name().clone())
+                        .collect();
+                    protobuf::ProjectionColumns {
+                        columns
+                    }
+                });
 
                 let schema: protobuf::Schema = schema.as_ref().try_into()?;
 
                 node.scan = Some(protobuf::ScanNode {
                     path: path.to_owned(),
-                    projection: projected_field_names,
+                    projection: projection,
                     schema: Some(schema),
                     has_header: *has_header,
                     file_format: "csv".to_owned(),
@@ -133,16 +137,20 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
             } => {
                 let mut node = empty_logical_plan_node();
 
-                let projected_field_names = match projection {
-                    Some(p) => p.iter().map(|i| schema.field(*i).name().clone()).collect(),
-                    _ => vec![],
-                };
+                let projection = projection.as_ref().map(|column_indices| {
+                    let columns: Vec<String> = column_indices.iter()
+                        .map(|i| schema.field(*i).name().clone())
+                        .collect();
+                    protobuf::ProjectionColumns {
+                        columns
+                    }
+                });
 
                 let schema: protobuf::Schema = schema.as_ref().try_into()?;
 
                 node.scan = Some(protobuf::ScanNode {
                     path: path.to_owned(),
-                    projection: projected_field_names,
+                    projection: projection,
                     schema: Some(schema),
                     has_header: false,
                     file_format: "parquet".to_owned(),

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -393,8 +393,8 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                         .map(|n| *n as u32)
                         .collect(),
                     file_format: "csv".to_owned(),
-                    schema: Some(exec.schema().as_ref().try_into()?),
-                    has_header: false,
+                    schema: Some(exec.original_schema().as_ref().try_into()?),
+                    has_header: exec.has_header,
                     batch_size: exec.batch_size as u32,
                 });
                 Ok(node)


### PR DESCRIPTION
The original problem of failing integration test #261 was a symptom to several issues.

Integration test failed because type of `passenger_count` column was `Int64` instead of `Int32` which was provided in schema. This happened because CSV schema (along with some other options) was not actually serialized to protobuf before sending query to the executor. The executor infered schema instead and this is the source of `Int64` type in the result.

The second issue is that even though the projection parameter is optional in the plan description, it is serialized as repeated filed in protobuf message `ScanNode`. Repeated fields cannot be optional, so empty array was sent to the executor as the projection. This resulted in empty result from CSV scan because empty projection simply means "the user does not want any fields from me".

The last issue was related to the serialization of CSV scan execution node. `CsvScanExec` inside its `try_new` method filters schema so that only projected columns remain. This projected schema is then serialized into protobuf, but the original projection field remains. This causes index error when `CsvScanExec` is restored from protobuf because projected schema simply does not contain fields mentioned in projection field. I made a quick fix for this and serialized original schema into protobuf.

Unfortunately, I was not able to debug one more problem. Even though code builds successfully on my local machine, for some reason build inside docker does not see new protobuf message I added. I have tried to rebuild dependencies docker image, but still no luck :(