### PR TITLE
Refactored kubernetes guide to support a remote cluster

### DIFF
--- a/dev/download-nyctaxi-files.sh
+++ b/dev/download-nyctaxi-files.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-02.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-03.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-04.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-05.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-06.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-07.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-08.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-09.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-10.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-11.csv
-wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-12.csv
+ARG=
+if [ -z "${1}" ];
+then
+ARG="-P $1"
+fi
+
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-02.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-03.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-04.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-05.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-06.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-07.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-08.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-09.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-10.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-11.csv $ARG
+wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-12.csv $ARG

--- a/dev/split-csv.sh
+++ b/dev/split-csv.sh
@@ -1,0 +1,21 @@
+# $1: file to split
+# $2: number of lines per part
+# $3: directory to write parts to
+if [[ -z $1 || -z $2 || -z $3 ]]; then
+  echo 'You need to pass 3 variables.'
+  exit 1
+fi
+echo "splitting csv in parts by $2 lines each, to '$3/'..."
+
+set -e
+# see https://stackoverflow.com/questions/1411713/how-to-split-a-file-and-keep-the-first-line-in-each-of-the-pieces
+mkdir -p "$3"
+tail -n +2 $1 | split -l $2 - part-
+for file in part-*
+do
+    head -n 1 $1 > tmp_file
+    cat "$file" >> tmp_file
+    mv -f tmp_file "$3/$file.csv"
+    rm "$file"
+done
+echo "splitting completed."

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,254 +1,121 @@
 # Deploying Ballista to Kubernetes
 
-This document explains how to create a Ballista cluster of executors in Kubernetes.
+This document explains how to create a Ballista cluster in Kubernetes.
 
-## Prerequisites
+## Generic kubernetes
 
-You will need a Kubernetes cluster to deploy to. I recommend using 
-[Minikube](https://kubernetes.io/docs/tutorials/hello-minikube) for local testing, or Amazon's Elastic Kubernetes 
-Service (EKS). These instructions are for using Minikube on Ubuntu.
+This guide assumes that we have a kubernetes cluster and our role has permissions to:
 
-You will either need to use published Ballista Docker images or you will need to build Docker images locally.
+* list and create pods
+* list and create secrets
+* list and create persistent volumes and claims
+* create ClusterRole and ClusterRoleBinding
 
-Run the following command before building Docker images to ensure they go to the Docker context in Minikube.
+on the namespace `default`.
 
-```bash
-eval $(minikube -p minikube docker-env)
-```
+### Deploy volumes and write data to it
 
-## Create Minikube cluster
-
-Create a Minikube cluster using the docker driver.
+For this guide, we will create a persistent volume and claim and write data to it, which we can then query through Ballista.
+To do so, run
 
 ```bash
-minikube start --driver=docker --cpus=12
+kubectl apply -f kubernetes/pv.yaml
 ```
 
-## RBAC 
+and check that its status and the claim status is "Bound":
 
-Ballista will need permissions to list pods. We will apply the following yaml to create `list-pods` cluster role and 
-bind it to the default service account in the current namespace.
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: list-pods
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ballista-list-pods
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: list-pods
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: default
 ```
+kubectl get pv
+kubectl get pvc
+```
+
+Next, we will spawn a pod to download data from s3 and write to the persistent volume:
 
 ```bash
-kubectl apply -f rbac.yaml
+kubectl apply -f kubernetes/populate-data.yaml
 ```
 
-You should see the following output:
+This operation takes some time as we have some data to download. This is done when the pod `populate-data` on `kubectl get pods`
+shows status `Completed`. We can't deploy the cluster before this step is completed, as the volume can only be claimed by
+a single pod at the time. Feel free to change [populate-data.yaml](./populate-data.yaml) do dump a smaller CSV.
+
+### Setup credentials for pulling images
+
+We offer docker images on github that we can use to run the cluster.
+They require authentication to be pulled. For this, we will create a secret in k8s:
 
 ```bash
-clusterrole.rbac.authorization.k8s.io/list-pods created
-clusterrolebinding.rbac.authorization.k8s.io/ballista-list-pods created
+kubectl create secret docker-registry github \
+    --docker-server=docker.pkg.github.com \
+    --docker-username=$GITHUB_USERNAME \
+    --docker-password=$GITHUB_TOKEN \
+    --docker-email=jorgecarleitao@gmail.com
 ```
 
-## Mounting a volume
+where `$GITHUB_TOKEN` is an [OAuth token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for your `$USERNAME`.
 
-You will need to run [download-nyctaxi-files.sh](download-nyctaxi-files.sh) to download a subset of the [NYC Taxi data set](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page) and then edit [pv.yaml](../../../kubernetes/pv.yaml) to provide the correct path to these files.
-
-First, we need to mount the host path into the Minikube VM.
+### Give the cluster permissions to list pods
 
 ```bash
-minikube mount /mnt/:/mnt/
+kubectl apply -f kubernetes/rbac.yaml
 ```
 
-You should see output like this:
+This gives all pods running on namespace `default` permissions to list pods from the cluster's API
+and is necessary for scheduling.
 
-```asm
-Mounting host path /mnt/nyctaxi/ into VM as /mnt/nyctaxi ...
-  Mount type:   <no value>
-  User ID:      docker
-  Group ID:     docker
-  Version:      9p2000.L
-  Message Size: 262144
-  Permissions:  755 (-rwxr-xr-x)
-  Options:      map[]
-  Bind Address: 172.17.0.1:43715
-    Userspace file server: ufs starting
-Successfully mounted /mnt/nyctaxi/ to /mnt/nyctaxi
-```
+### Deploy Ballista
 
-Next, we will apply the following yaml to create a persistent volume and a persistent volume claim so that the specified host directory is available to the containers.
-
-```yaml
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: nyctaxi-pv
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage: 10Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: "/mnt/nyctaxi"
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: nyctaxi-pv-claim
-spec:
-  storageClassName: manual
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 3Gi
-```
-
-Create a persistent volume.
+Once `populate-data` completes, we can bring the cluster up. For this, run
 
 ```bash
-kubectl apply -f pv.yaml
+kubectl apply -f kubernetes/ballista-cluster.yaml
 ```
 
-You should see the following output:
+We can check the status with `kubectl get pods` and `kubectl logs ballista-0`.
+This deploys two replicas and a service on port `50051`.
+At this point, we can connect remotely with this port to run queries against the cluster.
 
-```bash
-persistentvolume/nyctaxi-pv created
-persistentvolumeclaim/nyctaxi-pv-claim created
-```
-
-## Create Ballista Cluster
-
-We will apply the following yaml to create a service and a stateful set of twelve Rust executors. Note that can you simply change the docker image name from `ballistacompute/ballista-rust` to `ballistacompute/ballista-jvm` or `ballistacompute/ballista-spark` to use the JVM or Spark executor instead. 
-
-This definition will create twelve executors, using 1GB each. If you are running on a computer with limited memory available then you may want to reduce the number of replicas.
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: ballista
-  labels:
-    app: ballista
-spec:
-  ports:
-    - port: 50051
-      name: flight
-  clusterIP: None
-  selector:
-    app: ballista
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: ballista
-spec:
-  serviceName: "ballista"
-  replicas: 12
-  selector:
-    matchLabels:
-      app: ballista
-  template:
-    metadata:
-      labels:
-        app: ballista
-        ballista-cluster: ballista
-    spec:
-      containers:
-      - name: ballista
-        image: ballistacompute/ballista-rust:0.3.0-SNAPSHOT
-        resources:
-          requests:
-            cpu: "1"
-            memory: "1024Mi"
-          limits:
-            cpu: "1"
-            memory: "1024Mi"
-        ports:
-          - containerPort: 50051
-            name: flight
-        volumeMounts:
-          - mountPath: /mnt/nyctaxi
-            name: nyctaxi
-      volumes:
-      - name: nyctaxi
-        persistentVolumeClaim:
-          claimName: nyctaxi-pv-claim
-```
-
-Run the following kubectl command to deploy the Ballista cluster.
-
-```bash
-kubectl apply -f ballista-cluster-rust.yaml
-```
-
-You should see the following output:
-
-```
-service/ballista created
-statefulset.apps/ballista created
-```
-
-Run the `kubectl get pods` command to confirm that the pods are running. It will take a few seconds for all of the pods to start.
-
-```
-kubectl get pods
-NAME          READY   STATUS    RESTARTS   AGE
-ballista-0    1/1     Running   0          37s
-ballista-1    1/1     Running   0          33s
-ballista-10   1/1     Running   0          16s
-ballista-11   1/1     Running   0          15s
-ballista-2    1/1     Running   0          32s
-ballista-3    1/1     Running   0          30s
-ballista-4    1/1     Running   0          28s
-ballista-5    1/1     Running   0          27s
-ballista-6    1/1     Running   0          24s
-ballista-7    1/1     Running   0          22s
-ballista-8    1/1     Running   0          20s
-ballista-9    1/1     Running   0          18s
-```
-
-Run the `kubectl logs ballista-0` command to see logs from the first executor to confirm that the correct version is running and that there are no errors.
-
-```
-Ballista v0.3.0 Rust Executor listening on V4(0.0.0.0:50051)
-```
-
-## Port Forwarding
+A simple method to connect to it is to port-forward to our local machine:
 
 ```bash
 kubectl port-forward service/ballista 50051:50051
 ```
 
+and connect to this port to run queries against the cluster. In particular, 
+we can use [this example](../rust/examples/distributed-query) to query the cluster.
+
+### Customization
+
+The procedure above is a minimal setup to deploy ballista on kubernetes. From here, we can just change any configuration above
+to our needs. In particular, we can use the image name from `ballistacompute/ballista-rust` to `ballistacompute/ballista-jvm` or `ballistacompute/ballista-spark` to use a different executor.
+
+## Deploy on minikube
+
+For local development, we can also use minikube. We can set it up exactly the same way, but since 
+minikube runs locally, we can simplify the deployment a bit:
+
+First, we can use docker images from our own docker deamon,
+
+```bash
+eval $(minikube -p minikube docker-env)
+minikube start --driver=docker
 ```
-Forwarding from 127.0.0.1:50051 -> 50051
-Forwarding from [::1]:50051 -> 50051
+
+which does not require setting up a github access token.
+
+Secondly, we can use a local mounted volume before creating a persistent volume:
+
+```bash
+minikube mount /mnt/:/mnt/
 ```
+
+This way, we can download the data to our computer and place it in the mounted volume.
 
 ## Teardown
 
-Run the following kubectl command to delete the Ballista cluster.
+To revert all the steps above, we run `kubectl delete -f` on each of the files above. To delete the secret used
+to download images, run
 
 ```bash
-kubectl delete -f ballista-cluster-rust.yaml
+kubectl delete secret github
 ```

--- a/kubernetes/ballista-cluster.yaml
+++ b/kubernetes/ballista-cluster.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ballista
+  labels:
+    app: ballista
+spec:
+  ports:
+    - port: 50051
+      name: flight
+  clusterIP: None
+  selector:
+    app: ballista
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ballista
+spec:
+  serviceName: "ballista"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ballista
+  template:
+    metadata:
+      labels:
+        app: ballista
+        ballista-cluster: ballista
+    spec:
+      containers:
+      - name: ballista
+        image: docker.pkg.github.com/ballista-compute/ballista/ballista-rust:main
+        command: ["/executor"]
+        args: ["--mode=k8s", "--external-host=0.0.0.0", "--port=50051", "--concurrent-tasks=6"]
+        ports:
+          - containerPort: 50051
+            name: flight
+        volumeMounts:
+          - mountPath: /mnt
+            name: data
+      imagePullSecrets:
+      - name: github
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: data-pv-claim

--- a/kubernetes/populate-data.yaml
+++ b/kubernetes/populate-data.yaml
@@ -6,9 +6,12 @@ spec:
   containers:
   - name: populate-data
     image: alpine:3.12.0
-    command: ["https://raw.githubusercontent.com/ballista-compute/ballista/main/dev/download-nyctaxi-files.sh", "|", "bash", "-s", "/mnt"]
-    # small file:
-    #command: ["wget", "http://samplecsvs.s3.amazonaws.com/SacramentocrimeJanuary2006.csv", "-P", "/mnt"]
+    command: ["/bin/sh", "-c"]
+    # download file; split it in ~10 parts; rm file
+    args:
+      - wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv -P /mnt &&
+        wget -O - https://raw.githubusercontent.com/ballista-compute/ballista/main/dev/split-csv.sh | /bin/sh -s /mnt/yellow_tripdata_2019-01.csv 766779 /mnt/nztaxi.csv &&
+        rm -rf /mnt/yellow_tripdata_2019-01.csv
     volumeMounts:
     - mountPath: /mnt
       name: data

--- a/kubernetes/populate-data.yaml
+++ b/kubernetes/populate-data.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: populate-data
+spec:
+  containers:
+  - name: populate-data
+    image: alpine:3.12.0
+    command: ["https://raw.githubusercontent.com/ballista-compute/ballista/main/dev/download-nyctaxi-files.sh", "|", "bash", "-s", "/mnt"]
+    # small file:
+    #command: ["wget", "http://samplecsvs.s3.amazonaws.com/SacramentocrimeJanuary2006.csv", "-P", "/mnt"]
+    volumeMounts:
+    - mountPath: /mnt
+      name: data
+  restartPolicy: Never
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: data-pv-claim

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -7,7 +7,7 @@ rules:
   - ""
   resources:
   - pods
-  verbs: ["get", "watch", "list", "create", "edit", "delete"]
+  verbs: ["list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The aim of this PR is to have a simple configuration that new users can use to deploy Ballista on a generic kubernetes cluster.

There are two main differences between a generic k8 and minikube from the current deployment's perspective:

* docker images must be pulled from somewhere (and not just built)
* files must be dumped in persistent volumes (and not just mounted)

This commit:

* Adds a yaml with a job to populate the data to the persistent volume, so that we do not rely on local mounts
* Adds a yaml configuration that:
    * has a `imagePullSecrets` to kubernetes be able to pull images from github.
    * uses the image `docker.pkg.github.com/ballista-compute/ballista/ballista-rust:main`, so that when this code is pulled from `main`, that is also the image that is deployed on kubernetes
    * significantly reduces the requirements for the cluster: 2 replicas instead of 12, no memory or cpu needs
* generalizes the instructions to deploy ballista on any kubernetes cluster, thus allowing the user to run it out-of-the box on a managed cluster.
* removes most code on `kubernetes/README.md`, since we have it on the repository as yaml files. This reduces the maintenance cost of maintaining two copies of the files (that had already drifted).
* reduces verbs on the ClusterRole to only list pods, since the other verbs are not needed.

At some point we should have an Helm Chart, as we should ideally have a chart that allows the different configurations.

In this journey, the largest pain point was the time it takes to download of the data. I think that we should have a smaller dataset for new users play with.