### PR TITLE
[WIP] Hash Aggregate Performance

### DIFF
--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -48,7 +48,6 @@ prost-build = { version = "0.6.1" }
 [dev-dependencies]
 criterion = "0.3"
 
-# benches commented out for now because docker images need updating to work with them
-#[[bench]]
-#name = "hash_agg"
-#harness = false
+[[bench]]
+name = "hash_agg"
+harness = false

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -48,6 +48,7 @@ prost-build = { version = "0.6.1" }
 [dev-dependencies]
 criterion = "0.3"
 
-[[bench]]
-name = "hash_agg"
-harness = false
+#TODO update docker packaging to support this
+#[[bench]]
+#name = "hash_agg"
+#harness = false

--- a/rust/ballista/benches/hash_agg.rs
+++ b/rust/ballista/benches/hash_agg.rs
@@ -1,7 +1,29 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use ballista::arrow::datatypes::{DataType, Field, Schema};
-use ballista::datafusion::logicalplan::ScalarValue;
+use ballista::datafusion::logicalplan::{self, Expr, ScalarValue};
+use ballista::distributed::context::BallistaContext;
+use ballista::distributed::executor::{DiscoveryMode, ExecutorConfig};
 use ballista::execution::expressions::{col, sum};
-use ballista::execution::physical_plan::{AggregateMode, ColumnarValue};
+use ballista::execution::operators::{HashAggregateExec, InMemoryTableScanExec};
+use ballista::execution::physical_plan::{
+    AggregateMode, ColumnarValue, ExecutionPlan, PhysicalPlan,
+};
 use ballista::utils::datagen::DataGen;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -21,12 +43,42 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("sum accum array", |b| b.iter(|| accum.accumulate(&array)));
 
-    c.bench_function("sum accum scalar none", |b| {
+    c.bench_function("sum accum scalar some", |b| {
         b.iter(|| accum.accumulate(&ColumnarValue::Scalar(Some(ScalarValue::Float64(0_f64)), 1)))
     });
 
-    c.bench_function("sum accum scalar some", |b| {
+    c.bench_function("sum accum scalar none", |b| {
         b.iter(|| accum.accumulate(&ColumnarValue::Scalar(None, 1)))
+    });
+
+    let config = ExecutorConfig::new(DiscoveryMode::Standalone, "", 0, "", 2);
+    let ctx = Arc::new(BallistaContext::new(&config, HashMap::new()));
+    let table = Arc::new(PhysicalPlan::InMemoryTableScan(Arc::new(
+        InMemoryTableScanExec::new(vec![batch.clone(), batch]),
+    )));
+
+    c.bench_function("hash agg partial", |b| {
+        b.iter(|| {
+            let ctx = ctx.clone();
+            let table = table.clone();
+            smol::run(async move {
+                let hash_agg_exec = Arc::new(
+                    HashAggregateExec::try_new(
+                        AggregateMode::Partial,
+                        vec![logicalplan::col("c0")],
+                        vec![Expr::AggregateFunction {
+                            name: "sum".to_owned(),
+                            args: vec![logicalplan::col("c1")],
+                            return_type: DataType::Float64,
+                        }],
+                        table,
+                    )
+                    .unwrap(),
+                );
+                let stream = hash_agg_exec.execute(ctx, 0).await.unwrap();
+                while let Some(_) = stream.next().await.unwrap() {}
+            })
+        })
     });
 }
 

--- a/rust/ballista/src/execution/operators/hash_aggregate.rs
+++ b/rust/ballista/src/execution/operators/hash_aggregate.rs
@@ -18,7 +18,8 @@
 //! Ballista Hash Aggregate operator. This is based on the implementation from DataFusion in the
 //! Apache Arrow project.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use crate::arrow::array::StringBuilder;
@@ -30,13 +31,10 @@ use crate::error::{ballista_error, BallistaError, Result};
 use crate::execution::physical_plan::{
     compile_aggregate_expressions, compile_expressions, Accumulator, AggregateExpr, AggregateMode,
     ColumnarBatch, ColumnarBatchIter, ColumnarBatchStream, ColumnarValue, Distribution,
-    ExecutionContext, ExecutionPlan, Expression, MaybeColumnarBatch, Partitioning, PhysicalPlan,
+    ExecutionContext, ExecutionPlan, Expression, Partitioning, PhysicalPlan,
 };
 
 use async_trait::async_trait;
-use crossbeam::channel::{unbounded, Receiver, Sender};
-use smol::Task;
-use std::collections::HashMap;
 
 /// HashAggregateExec applies a hash aggregate operation against its input.
 #[allow(dead_code)]
@@ -230,140 +228,6 @@ macro_rules! update_accumulators {
 /// AccumularSet is the value in the hash map
 type AccumulatorSet = Vec<Box<dyn Accumulator>>;
 
-#[allow(dead_code)]
-struct HashAggregateIter {
-    schema: Arc<Schema>,
-    rx: Receiver<MaybeColumnarBatch>,
-}
-
-fn run(
-    tx: Sender<MaybeColumnarBatch>,
-    mode: &AggregateMode,
-    input: ColumnarBatchStream,
-    group_expr: Vec<Arc<dyn Expression>>,
-    aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-    debug: bool,
-) -> Result<()> {
-    smol::run(async {
-        // metrics
-        let start = Instant::now();
-        let mut read_batch_time = 0;
-        let mut accum_batch_time = 0;
-        let mut batch_count = 0;
-        let mut row_count = 0;
-
-        // hash map of grouping values to accumulators
-        let mut map: HashMap<Vec<GroupByScalar>, AccumulatorSet> = HashMap::new();
-
-        // create vector large enough to hold the grouping key that can be re-used per row to
-        // avoid the cost of creating a new vector each time
-        let mut key = Vec::with_capacity(group_expr.len());
-        for _ in 0..group_expr.len() {
-            key.push(GroupByScalar::UInt32(0));
-        }
-
-        // iterate over all the input batches .. note that in partial mode it would be valid
-        // to emit batches periodically and reset the accumulator map to reduce memory pressure
-        loop {
-            let read_batch_start = Instant::now();
-            let maybe_batch = input.next().await?;
-            read_batch_time += read_batch_start.elapsed().as_millis();
-
-            match maybe_batch {
-                Some(batch) => {
-                    batch_count += 1;
-                    row_count += batch.num_rows();
-
-                    let accum_start = Instant::now();
-
-                    // evaluate the grouping expressions against this batch
-                    let group_values = group_expr
-                        .iter()
-                        .map(|e| e.evaluate(&batch))
-                        .collect::<Result<Vec<_>>>()?;
-
-                    // evaluate the input expressions to the aggregate functions
-                    let aggr_input_values = aggr_expr
-                        .iter()
-                        .map(|e| e.evaluate_input(&batch))
-                        .collect::<Result<Vec<_>>>()?;
-
-                    // we now need to switch to row-based processing :-(
-                    for row in 0..batch.num_rows() {
-                        // create grouping key for this row
-                        create_key(&group_values, row, &mut key)?;
-
-                        // lookup the accumulators for this grouping key
-                        let updated = match map.get_mut(&key) {
-                            Some(mut accumulators) => {
-                                accumulate(&aggr_input_values, &mut accumulators, row)?;
-                                true
-                            }
-                            None => false,
-                        };
-
-                        // create the accumulators for this grouping key if they weren't found
-                        if !updated {
-                            let mut accumulators: AccumulatorSet = aggr_expr
-                                .iter()
-                                .map(|expr| expr.create_accumulator(&mode))
-                                .collect();
-
-                            accumulate(&aggr_input_values, &mut accumulators, row)?;
-
-                            map.insert(key.clone(), accumulators);
-                        }
-                    }
-                    accum_batch_time += accum_start.elapsed().as_millis();
-                }
-                None => break,
-            }
-        }
-
-        // prepare results
-        let prepare_final_batch_start = Instant::now();
-        let batch = create_batch_from_accum_map(
-            &map,
-            input.as_ref().schema().as_ref(),
-            &group_expr,
-            &aggr_expr,
-        )?;
-        let create_final_batch_time = prepare_final_batch_start.elapsed().as_millis();
-
-        // send the result batch over the channel
-        tx.send(Ok(Some(batch))).map_err(|e| {
-            ballista_error(&format!("Error sending hash aggregate result: {:?}", e))
-        })?;
-
-        // send EOF marker
-        tx.send(Ok(None)).map_err(|e| {
-            ballista_error(&format!(
-                "Error sending hash aggregate end-of-stream: {:?}",
-                e
-            ))
-        })?;
-
-        // temporary measure to be able to toggle showing metrics until we have a metrics
-        // reporting framework
-        if debug {
-            println!(
-                "HashAggregate processed {} batches and {} rows. \
-                Reading: {} ms; Accumulating: {} ms; Create result: {} ms. \
-                Total duration {} ms.",
-                batch_count,
-                row_count,
-                read_batch_time,
-                accum_batch_time,
-                create_final_batch_time,
-                start.elapsed().as_millis()
-            );
-        }
-
-        Ok(())
-    })
-}
-
-#[inline]
 fn accumulate(
     aggr_input_values: &[ColumnarValue],
     accumulators: &mut AccumulatorSet,
@@ -466,6 +330,18 @@ fn accumulate(
     Ok(())
 }
 
+#[allow(dead_code)]
+struct HashAggregateIter {
+    mode: AggregateMode,
+    input: ColumnarBatchStream,
+    group_expr: Vec<Arc<dyn Expression>>,
+    aggr_expr: Vec<Arc<dyn AggregateExpr>>,
+    schema: Arc<Schema>,
+    eof: Arc<Mutex<bool>>,
+    debug: bool,
+}
+
+
 impl HashAggregateIter {
     fn new(
         mode: &AggregateMode,
@@ -474,19 +350,16 @@ impl HashAggregateIter {
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
         output_schema: Arc<Schema>,
         debug: bool,
+
     ) -> Self {
-        let (tx, rx): (Sender<MaybeColumnarBatch>, Receiver<MaybeColumnarBatch>) = unbounded();
-
-        let mode = mode.clone();
-        let _ = std::thread::spawn(move || {
-            if let Err(e) = run(tx, &mode, input, group_expr, aggr_expr, debug) {
-                println!("HashAggregateExec thread terminated with error: {:?}", e);
-            }
-        });
-
         Self {
+            mode: mode.to_owned(),
+            input,
+            group_expr,
+            aggr_expr,
             schema: output_schema,
-            rx,
+            eof: Arc::new(Mutex::new(false)),
+            debug,
         }
     }
 }
@@ -628,13 +501,122 @@ impl ColumnarBatchIter for HashAggregateIter {
     }
 
     async fn next(&self) -> Result<Option<ColumnarBatch>> {
-        let channel = self.rx.clone();
-        Task::blocking(async move {
-            channel
-                .recv()
-                .map_err(|e| BallistaError::General(format!("{:?}", e.to_string())))?
-        })
-        .await
+        
+        {
+            let mut eof = self.eof.lock().expect("failed to lock mutex");
+            if *eof {
+                return Ok(None);
+            }
+            *eof = true;
+        }
+
+        let start = Instant::now();
+        let mut read_batch_time = 0;
+        let mut accum_batch_time = 0;
+        let mut batch_count = 0;
+        let mut row_count = 0;
+
+        // hash map of grouping keys to accumulators
+        let mut map: HashMap<Vec<GroupByScalar>, AccumulatorSet> = HashMap::new();
+
+        // create vector large enough to hold the grouping key that can be re-used per row to
+        // avoid the cost of creating a new vector each time
+        let mut key = Vec::with_capacity(self.group_expr.len());
+        for _ in 0..self.group_expr.len() {
+            key.push(GroupByScalar::UInt32(0));
+        }
+
+        // iterate over all the input batches .. note that in partial mode it would be valid
+        // to emit batches periodically and reset the accumulator map to reduce memory pressure
+        loop {
+            let read_batch_start = Instant::now();
+            let maybe_batch = self.input.next().await?;
+            read_batch_time += read_batch_start.elapsed().as_millis();
+
+            match maybe_batch {
+                Some(batch) => {
+                    batch_count += 1;
+                    row_count += batch.num_rows();
+
+                    let accum_start = Instant::now();
+
+                    // evaluate the grouping expressions against this batch
+                    let group_values = self.group_expr
+                        .iter()
+                        .map(|e| e.evaluate(&batch))
+                        .collect::<Result<Vec<_>>>()?;
+
+                    // evaluate the input expressions to the aggregate functions
+                    let aggr_input_values = self.aggr_expr
+                        .iter()
+                        .map(|e| e.evaluate_input(&batch))
+                        .collect::<Result<Vec<_>>>()?;
+
+                    // we now need to switch to row-based processing :-(
+                    for row in 0..batch.num_rows() {
+                        // create grouping key for this row
+                        create_key(&group_values, row, &mut key)?;
+
+                        // lookup the accumulators for this grouping key
+                        let updated = match map.get_mut(&key) {
+                            Some(mut accumulators) => {
+                                accumulate(&aggr_input_values, &mut accumulators, row)?;
+                                true
+                            }
+                            None => false,
+                        };
+
+                        // create the accumulators for this grouping key if they weren't found
+                        if !updated {
+                            let mut accumulators: AccumulatorSet = self.aggr_expr
+                                .iter()
+                                .map(|expr| expr.create_accumulator(&self.mode))
+                                .collect();
+
+                            accumulate(&aggr_input_values, &mut accumulators, row)?;
+
+                            map.insert(key.clone(), accumulators);
+                        }
+                    }
+                    accum_batch_time += accum_start.elapsed().as_millis();
+                }
+                None => break,
+            }
+        }
+
+        if map.is_empty() {
+            Ok(None)
+        } else {
+
+            // prepare results
+            let prepare_final_batch_start = Instant::now();
+            let batch = create_batch_from_accum_map(
+                &map,
+                self.input.as_ref().schema().as_ref(),
+                &self.group_expr,
+                &self.aggr_expr,
+            )?;
+            let create_final_batch_time = prepare_final_batch_start.elapsed().as_millis();
+
+            // temporary measure to be able to toggle showing metrics until we have a metrics
+            // reporting framework
+            if self.debug {
+                println!(
+                    "HashAggregate processed {} batches and {} rows. \
+                    Reading: {} ms; Accumulating: {} ms; Create result: {} ms. \
+                    Total duration {} ms.",
+                    batch_count,
+                    row_count,
+                    read_batch_time,
+                    accum_batch_time,
+                    create_final_batch_time,
+                    start.elapsed().as_millis()
+                );
+            }
+
+            // send the result batch over the channel
+            Ok(Some(batch))
+        }
     }
 }
 

--- a/rust/ballista/tests/query_execution.rs
+++ b/rust/ballista/tests/query_execution.rs
@@ -1,3 +1,17 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 extern crate ballista;
 
 use std::sync::Arc;


### PR DESCRIPTION
- Remove unnecessary use of thread and channel from HashAggregateExec
- Implement micro-benchmark for HashAggregateExec

The micro-benchmark showed a 68% improvement but TPCH is no faster.