### PR TITLE
Parquet performance

### DIFF
--- a/integration-tests/rust/Cargo.lock
+++ b/integration-tests/rust/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "num",
+ "packed_simd",
  "prettytable-rs",
  "rand 0.7.3",
  "regex",
@@ -117,6 +118,17 @@ dependencies = [
  "tokio 0.2.21",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43de69555a39d52918e2bc33a408d3c0a86c829b212d898f4ca25d21a6387478"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
 ]
 
 [[package]]
@@ -213,6 +225,7 @@ version = "0.3.0-SNAPSHOT"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "async-channel",
  "async-trait",
  "crossbeam",
  "datafusion",
@@ -424,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
@@ -717,6 +730,12 @@ dependencies = [
  "tonic",
  "tonic-build",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f14646a9e0430150a87951622ba9675472b68e384b7701b8423b30560805c7a"
 
 [[package]]
 name = "failure"
@@ -1643,6 +1662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "packed_simd"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/integration-tests/rust/src/main.rs
+++ b/integration-tests/rust/src/main.rs
@@ -59,7 +59,7 @@ async fn execute(path: &str, host: &str, name: &&str, port: &usize) -> Result<St
     settings.insert(CSV_READER_BATCH_SIZE, "1024");
     let ctx = Context::remote(host, *port, settings);
     let response = ctx
-        .read_csv(path, CsvReadOptions::new().schema(&nyctaxi_schema()), None)?
+        .read_csv(path, CsvReadOptions::new().schema(&nyctaxi_schema()))?
         .aggregate(
             vec![col("passenger_count")],
             vec![min(col("fare_amount")), max(col("fare_amount"))],

--- a/proto/ballista.proto
+++ b/proto/ballista.proto
@@ -145,6 +145,9 @@ message ScanExecNode {
   bool has_header = 5; // csv specific
   uint32 batch_size = 6;
   uint32 queue_size = 7; // parquet specific
+
+  // partition filenames
+  repeated string filename = 8;
 }
 
 message ProjectionExecNode {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,6 +121,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43de69555a39d52918e2bc33a408d3c0a86c829b212d898f4ca25d21a6387478"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +225,7 @@ version = "0.3.0-SNAPSHOT"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "async-channel",
  "async-trait",
  "criterion",
  "crossbeam",
@@ -427,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
@@ -765,6 +777,12 @@ dependencies = [
  "tonic",
  "tonic-build",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f14646a9e0430150a87951622ba9675472b68e384b7701b8423b30560805c7a"
 
 [[package]]
 name = "failure"

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -25,6 +25,7 @@ prost-types = "0.6"
 reqwest = "0.9.18"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 sqlparser = "0.2.6"
+async-channel = "1.4.0"
 crossbeam = "0.7"
 smol = { version = "0.1.18", features = ["tokio02"] }
 async-trait = "0.1.36"

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -145,6 +145,9 @@ message ScanExecNode {
   bool has_header = 5; // csv specific
   uint32 batch_size = 6;
   uint32 queue_size = 7; // parquet specific
+
+  // partition filenames
+  repeated string filename = 8;
 }
 
 message ProjectionExecNode {

--- a/rust/ballista/src/dataframe.rs
+++ b/rust/ballista/src/dataframe.rs
@@ -240,26 +240,17 @@ impl Context {
         Ok(DataFrame::from(self.state.clone(), plan))
     }
 
-    pub fn read_csv(
-        &self,
-        path: &str,
-        options: CsvReadOptions,
-        projection: Option<Vec<usize>>,
-    ) -> Result<DataFrame> {
+    pub fn read_csv(&self, path: &str, options: CsvReadOptions) -> Result<DataFrame> {
         Ok(DataFrame::scan_csv(
             self.state.clone(),
             path,
             options,
-            projection,
+            None,
         )?)
     }
 
-    pub fn read_parquet(&self, path: &str, projection: Option<Vec<usize>>) -> Result<DataFrame> {
-        Ok(DataFrame::scan_parquet(
-            self.state.clone(),
-            path,
-            projection,
-        )?)
+    pub fn read_parquet(&self, path: &str) -> Result<DataFrame> {
+        Ok(DataFrame::scan_parquet(self.state.clone(), path, None)?)
     }
 
     pub fn sql(&self, sql: &str) -> Result<DataFrame> {

--- a/rust/ballista/src/execution/operators/csv_scan.rs
+++ b/rust/ballista/src/execution/operators/csv_scan.rs
@@ -22,7 +22,6 @@ use std::sync::{Arc, Mutex};
 
 use crate::arrow::csv;
 use crate::arrow::datatypes::{Schema, SchemaRef};
-use crate::datafusion::execution::physical_plan::common::build_file_list;
 use crate::datafusion::execution::physical_plan::csv::CsvReadOptions;
 use crate::error::{ballista_error, Result};
 
@@ -56,17 +55,11 @@ impl CsvScanExec {
     /// Create a new execution plan for reading a set of CSV files
     pub fn try_new(
         path: &str,
+        filenames: Vec<String>,
         options: CsvReadOptions,
         projection: Option<Vec<usize>>,
         batch_size: usize,
     ) -> Result<Self> {
-        // build list of partition files
-        let mut filenames: Vec<String> = vec![];
-        build_file_list(path, &mut filenames, ".csv")?;
-        if filenames.is_empty() {
-            return Err(ballista_error("No files found"));
-        }
-
         let schema = match options.schema {
             Some(s) => s.clone(),
             None => CsvScanExec::try_infer_schema(&filenames, &options)?,

--- a/rust/ballista/src/serde/from_proto.rs
+++ b/rust/ballista/src/serde/from_proto.rs
@@ -404,6 +404,7 @@ impl TryInto<PhysicalPlan> for &protobuf::PhysicalPlanNode {
 
                     Ok(PhysicalPlan::CsvScan(Arc::new(CsvScanExec::try_new(
                         &scan.path,
+                        scan.filename.clone(),
                         options,
                         Some(projection),
                         scan.batch_size as usize,
@@ -412,6 +413,7 @@ impl TryInto<PhysicalPlan> for &protobuf::PhysicalPlanNode {
                 "parquet" => Ok(PhysicalPlan::ParquetScan(Arc::new(
                     ParquetScanExec::try_new(
                         &scan.path,
+                        scan.filename.clone(),
                         Some(scan.projection.iter().map(|n| *n as usize).collect()),
                         scan.batch_size as usize,
                         scan.queue_size as usize,

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -408,6 +408,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                 let mut node = empty_physical_plan_node();
                 node.scan = Some(protobuf::ScanExecNode {
                     path: exec.path.clone(),
+                    filename: exec.filenames.clone(),
                     projection: exec
                         .projection
                         .as_ref()
@@ -432,6 +433,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                 // };
                 node.scan = Some(protobuf::ScanExecNode {
                     path: exec.path.clone(),
+                    filename: exec.filenames.clone(),
                     projection: exec
                         .projection
                         .as_ref()

--- a/rust/examples/apache-spark-rust-bindings/src/main.rs
+++ b/rust/examples/apache-spark-rust-bindings/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     let path = "/mnt/nyctaxi/csv/yellow/2019/yellow_tripdata_2019-01.csv";
 
     let df = ctx
-        .read_csv(path, CsvReadOptions::new().schema(&nyctaxi_schema()), None)?
+        .read_csv(path, CsvReadOptions::new().schema(&nyctaxi_schema()))?
         //.filter(col("passenger_count").gt(&lit))?
         .aggregate(
             vec![col("passenger_count")],

--- a/rust/examples/distributed-query/src/main.rs
+++ b/rust/examples/distributed-query/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
     let ctx = Context::remote(executor_host, executor_port, HashMap::new());
 
     let results = ctx
-        .read_parquet(path, None)?
+        .read_parquet(path)?
         .aggregate(vec![col("passenger_count")], vec![max(col("fare_amount"))])?
         .collect()
         .await?;

--- a/rust/examples/tpch/src/main.rs
+++ b/rust/examples/tpch/src/main.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::process::exit;
 use std::time::Instant;
 
 extern crate ballista;
@@ -21,10 +22,9 @@ use ballista::arrow::datatypes::{DataType, Field, Schema};
 use ballista::arrow::record_batch::RecordBatch;
 use ballista::arrow::util::pretty;
 use ballista::dataframe::*;
+use ballista::datafusion::execution::physical_plan::csv::CsvReadOptions;
 use ballista::error::Result;
 
-use ballista::datafusion::execution::physical_plan::csv::CsvReadOptions;
-use std::process::exit;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -35,6 +35,9 @@ struct Opt {
 
     #[structopt()]
     path: String,
+
+    #[structopt()]
+    query: usize,
 
     #[structopt(short = "h", long = "host", default_value = "localhost")]
     executor_host: String,
@@ -53,6 +56,7 @@ async fn main() -> Result<()> {
     let opt: Opt = Opt::from_args();
     let format = opt.format.as_str();
     let path = opt.path.as_str();
+    let query_no = opt.query;
     let executor_host = opt.executor_host.as_str();
     let executor_port = opt.executor_port;
 
@@ -65,8 +69,6 @@ async fn main() -> Result<()> {
         }
     };
 
-    let query_no = 1;
-
     let start = Instant::now();
 
     let mut settings = HashMap::new();
@@ -78,7 +80,10 @@ async fn main() -> Result<()> {
     let results = match query_no {
         1 => q1(&ctx, path, &format).await?,
         6 => q6(&ctx, path, &format).await?,
-        _ => unimplemented!(),
+        _ => {
+            println!("Invalid query no");
+            exit(-1);
+        }
     };
 
     // print the results


### PR DESCRIPTION
- Perform file scan once in scheduler instead of in each parquet scan exec instance
- Use async channel
- Minor DataFrame API cleanup
- Make file format configurable in TPC-H example