### PR TITLE
[Rust] Remove async from ColumnBatchIter

### DIFF
--- a/proto/ballista.proto
+++ b/proto/ballista.proto
@@ -144,7 +144,6 @@ message ScanExecNode {
   string file_format = 4; // parquet or csv
   bool has_header = 5; // csv specific
   uint32 batch_size = 6;
-  uint32 queue_size = 7; // parquet specific
 
   // partition filenames
   repeated string filename = 8;

--- a/rust/ballista/benches/hash_agg.rs
+++ b/rust/ballista/benches/hash_agg.rs
@@ -76,7 +76,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     .unwrap(),
                 );
                 let stream = hash_agg_exec.execute(ctx, 0).await.unwrap();
-                while let Some(_) = stream.next().await.unwrap() {}
+                while let Some(_) = stream.next().unwrap() {}
             })
         })
     });

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -144,7 +144,6 @@ message ScanExecNode {
   string file_format = 4; // parquet or csv
   bool has_header = 5; // csv specific
   uint32 batch_size = 6;
-  uint32 queue_size = 7; // parquet specific
 
   // partition filenames
   repeated string filename = 8;

--- a/rust/ballista/src/dataframe.rs
+++ b/rust/ballista/src/dataframe.rs
@@ -34,7 +34,6 @@ use crate::execution::physical_plan::Action;
 
 pub const CSV_READER_BATCH_SIZE: &str = "ballista.csv.reader.batchSize";
 pub const PARQUET_READER_BATCH_SIZE: &str = "ballista.parquet.reader.batchSize";
-pub const PARQUET_READER_QUEUE_SIZE: &str = "ballista.parquet.reader.queueSize";
 
 /// Configuration setting
 #[derive(Debug, Clone)]
@@ -81,14 +80,6 @@ impl BallistaConfigs {
             "Number of rows to read per batch",
             DataType::UInt64,
             Some("65536"),
-        ));
-
-        configs.push(ConfigSetting::new(
-            PARQUET_READER_QUEUE_SIZE,
-            "Size of the bounded queue that sends batches from the Parquet reader thread to the\
-            next upstream operator.",
-            DataType::UInt64,
-            Some("2"),
         ));
 
         let mut config_map: HashMap<String, ConfigSetting> = HashMap::new();

--- a/rust/ballista/src/distributed/executor.rs
+++ b/rust/ballista/src/distributed/executor.rs
@@ -226,7 +226,7 @@ async fn execute_task(
     let exec_plan = task.plan.as_execution_plan();
     let stream = exec_plan.execute(ctx, task.partition_id).await?;
     let mut batches = vec![];
-    while let Some(batch) = stream.next().await? {
+    while let Some(batch) = stream.next()? {
         batches.push(batch.to_arrow()?);
     }
 

--- a/rust/ballista/src/distributed/scheduler.rs
+++ b/rust/ballista/src/distributed/scheduler.rs
@@ -25,7 +25,6 @@ use std::time::{Duration, Instant};
 use crate::arrow::datatypes::Schema;
 use crate::dataframe::{
     avg, count, max, min, sum, CSV_READER_BATCH_SIZE, PARQUET_READER_BATCH_SIZE,
-    PARQUET_READER_QUEUE_SIZE,
 };
 use crate::datafusion::execution::context::ExecutionContext as DFContext;
 use crate::datafusion::execution::physical_plan::common;
@@ -728,14 +727,7 @@ pub fn create_physical_plan(
             let batch_size: usize = settings[PARQUET_READER_BATCH_SIZE]
                 .parse()
                 .unwrap_or(64 * 1024);
-            let queue_size: usize = settings[PARQUET_READER_QUEUE_SIZE].parse().unwrap_or(2);
-            let exec = ParquetScanExec::try_new(
-                path,
-                filenames,
-                projection.clone(),
-                batch_size,
-                queue_size,
-            )?;
+            let exec = ParquetScanExec::try_new(path, filenames, projection.clone(), batch_size)?;
             Ok(Arc::new(PhysicalPlan::ParquetScan(Arc::new(exec))))
         }
         other => Err(BallistaError::General(format!(

--- a/rust/ballista/src/execution/operators/csv_scan.rs
+++ b/rust/ballista/src/execution/operators/csv_scan.rs
@@ -160,7 +160,6 @@ impl CsvBatchIter {
     }
 }
 
-#[async_trait]
 impl ColumnarBatchIter for CsvBatchIter {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/ballista/src/execution/operators/csv_scan.rs
+++ b/rust/ballista/src/execution/operators/csv_scan.rs
@@ -166,7 +166,7 @@ impl ColumnarBatchIter for CsvBatchIter {
         self.schema.clone()
     }
 
-    async fn next(&self) -> Result<Option<ColumnarBatch>> {
+    fn next(&self) -> Result<Option<ColumnarBatch>> {
         let mut reader = self.reader.lock().expect("failed to lock mutex");
         match reader.next() {
             Ok(Some(batch)) => Ok(Some(ColumnarBatch::from_arrow(&batch))),

--- a/rust/ballista/src/execution/operators/filter.rs
+++ b/rust/ballista/src/execution/operators/filter.rs
@@ -97,7 +97,6 @@ struct FilterIter {
     filter_expr: Arc<dyn Expression>,
 }
 
-#[async_trait]
 impl ColumnarBatchIter for FilterIter {
     fn schema(&self) -> Arc<Schema> {
         self.input.schema()

--- a/rust/ballista/src/execution/operators/filter.rs
+++ b/rust/ballista/src/execution/operators/filter.rs
@@ -103,8 +103,8 @@ impl ColumnarBatchIter for FilterIter {
         self.input.schema()
     }
 
-    async fn next(&self) -> Result<Option<ColumnarBatch>> {
-        match self.input.next().await? {
+    fn next(&self) -> Result<Option<ColumnarBatch>> {
+        match self.input.next()? {
             Some(input) => {
                 let bools = self.filter_expr.evaluate(&input)?;
                 let batch = apply_filter(&input, &bools, self.input.schema())?;

--- a/rust/ballista/src/execution/operators/hash_aggregate.rs
+++ b/rust/ballista/src/execution/operators/hash_aggregate.rs
@@ -493,7 +493,6 @@ fn create_batch_from_accum_map(
     Ok(ColumnarBatch::from_values_infer_schema(&values))
 }
 
-#[async_trait]
 impl ColumnarBatchIter for HashAggregateIter {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/ballista/src/execution/operators/hash_aggregate.rs
+++ b/rust/ballista/src/execution/operators/hash_aggregate.rs
@@ -499,7 +499,7 @@ impl ColumnarBatchIter for HashAggregateIter {
         self.schema.clone()
     }
 
-    async fn next(&self) -> Result<Option<ColumnarBatch>> {
+    fn next(&self) -> Result<Option<ColumnarBatch>> {
         if self.eof.load(Ordering::Relaxed) {
             return Ok(None);
         }
@@ -525,7 +525,7 @@ impl ColumnarBatchIter for HashAggregateIter {
         // to emit batches periodically and reset the accumulator map to reduce memory pressure
         loop {
             let read_batch_start = Instant::now();
-            let maybe_batch = self.input.next().await?;
+            let maybe_batch = self.input.next()?;
             read_batch_time += read_batch_start.elapsed().as_millis();
 
             match maybe_batch {

--- a/rust/ballista/src/execution/operators/in_memory.rs
+++ b/rust/ballista/src/execution/operators/in_memory.rs
@@ -76,7 +76,7 @@ impl ColumnarBatchIter for InMemoryTableScanIter {
         self.data[0].schema()
     }
 
-    async fn next(&self) -> Result<Option<ColumnarBatch>> {
+    fn next(&self) -> Result<Option<ColumnarBatch>> {
         let index = self.index.load(Ordering::SeqCst);
         if index < self.data.len() {
             self.index.store(index + 1, Ordering::SeqCst);

--- a/rust/ballista/src/execution/operators/in_memory.rs
+++ b/rust/ballista/src/execution/operators/in_memory.rs
@@ -70,7 +70,6 @@ impl InMemoryTableScanIter {
     }
 }
 
-#[async_trait]
 impl ColumnarBatchIter for InMemoryTableScanIter {
     fn schema(&self) -> Arc<Schema> {
         self.data[0].schema()

--- a/rust/ballista/src/execution/operators/parquet_scan.rs
+++ b/rust/ballista/src/execution/operators/parquet_scan.rs
@@ -18,23 +18,21 @@ use std::cell::RefCell;
 use std::fs::File;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Instant;
 
-use crate::error::{BallistaError, Result};
+use crate::error::Result;
 use crate::execution::physical_plan::{
     ColumnarBatch, ColumnarBatchIter, ColumnarBatchStream, ExecutionContext, ExecutionPlan,
-    MaybeColumnarBatch, Partitioning,
+    Partitioning,
 };
 
 use crate::arrow::datatypes::Schema;
 use crate::arrow::record_batch::RecordBatchReader;
 use crate::parquet::arrow::arrow_reader::ArrowReader;
+use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 use crate::parquet::arrow::ParquetFileArrowReader;
 use crate::parquet::file::reader::SerializedFileReader;
 
-use async_channel::{bounded, Receiver, Sender};
 use async_trait::async_trait;
-use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
 
 /// ParquetScanExec reads Parquet files and applies an optional projection so that only necessary
 /// columns are loaded into memory. The partitioning scheme is currently rather simplistic with a
@@ -48,7 +46,6 @@ pub struct ParquetScanExec {
     pub(crate) parquet_schema: Arc<Schema>,
     pub(crate) output_schema: Arc<Schema>,
     pub(crate) batch_size: usize,
-    pub(crate) queue_size: usize,
 }
 
 impl ParquetScanExec {
@@ -57,7 +54,6 @@ impl ParquetScanExec {
         filenames: Vec<String>,
         projection: Option<Vec<usize>>,
         batch_size: usize,
-        queue_size: usize,
     ) -> Result<Self> {
         let filename = &filenames[0];
         let file = File::open(filename)?;
@@ -84,7 +80,6 @@ impl ParquetScanExec {
             parquet_schema: Arc::new(schema),
             output_schema: Arc::new(projected_schema),
             batch_size,
-            queue_size,
         })
     }
 }
@@ -110,33 +105,34 @@ impl ExecutionPlan for ParquetScanExec {
             &self.filenames[partition_index],
             self.projection.clone(),
             self.batch_size,
-            self.queue_size,
         )?))
     }
 }
 
 pub struct ParquetBatchIter {
     schema: Arc<Schema>,
-    pub response_rx: Receiver<MaybeColumnarBatch>,
+    batch_reader: Rc<RefCell<ParquetRecordBatchReader>>,
 }
 
-#[allow(dead_code)]
 impl ParquetBatchIter {
     pub fn try_new(
         filename: &str,
         projection: Option<Vec<usize>>,
         batch_size: usize,
-        queue_size: usize,
     ) -> Result<Self> {
         let file = File::open(filename)?;
         let file_reader = Rc::new(SerializedFileReader::new(file).unwrap()); //TODO error handling
         let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
+
         let schema = arrow_reader.get_schema().unwrap(); //TODO error handling
 
         let projection = match projection {
             Some(p) => p,
             None => (0..schema.fields().len()).collect(),
         };
+        let batch_reader = arrow_reader
+            .get_record_reader_by_columns(projection.clone(), batch_size)
+            .unwrap();
 
         let projected_schema = Schema::new(
             projection
@@ -145,105 +141,23 @@ impl ParquetBatchIter {
                 .collect(),
         );
 
-        let (response_tx, response_rx): (Sender<MaybeColumnarBatch>, Receiver<MaybeColumnarBatch>) =
-            bounded(queue_size);
-
-        let filename = filename.to_string();
-        std::thread::spawn(move || {
-            smol::run(async move {
-                read_parquet_batches(&filename, response_tx, projection, batch_size).await;
-            })
-        });
-
         Ok(Self {
             schema: Arc::new(projected_schema),
-            response_rx,
+            batch_reader: Rc::new(RefCell::new(batch_reader)),
         })
     }
 }
 
-async fn read_parquet_batches(
-    filename: &str,
-    response_tx: Sender<MaybeColumnarBatch>,
-    projection: Vec<usize>,
-    batch_size: usize,
-) {
-    let start = Instant::now();
-    let mut batch_read_time = 0;
-    let mut total_bytes_read = 0;
-    let mut output_batches = 0;
-    let mut output_rows = 0;
-
-    //TODO error handling, remove unwraps
-    let file = File::open(&filename).unwrap();
-    match SerializedFileReader::new(file) {
-        Ok(file_reader) => {
-            let file_reader = Rc::new(file_reader);
-            let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
-            match arrow_reader.get_record_reader_by_columns(projection, batch_size) {
-                Ok(mut batch_reader) => loop {
-                    // read the next batch
-                    let start_batch = Instant::now();
-                    let maybe_batch = batch_reader.next_batch();
-                    batch_read_time += start_batch.elapsed().as_millis();
-
-                    match maybe_batch {
-                        Ok(Some(batch)) => {
-                            output_batches += 1;
-                            output_rows += batch.num_rows();
-                            let columnar_batch = ColumnarBatch::from_arrow(&batch);
-                            total_bytes_read += columnar_batch.memory_size();
-                            response_tx.send(Ok(Some(columnar_batch))).await.unwrap();
-                        }
-                        Ok(None) => {
-                            response_tx.send(Ok(None)).await.unwrap();
-                            break;
-                        }
-                        Err(e) => {
-                            response_tx
-                                .send(Err(BallistaError::General(format!("{:?}", e))))
-                                .await
-                                .unwrap();
-                            break;
-                        }
-                    }
-                },
-
-                Err(e) => {
-                    response_tx
-                        .send(Err(BallistaError::General(format!("{:?}", e))))
-                        .await
-                        .unwrap();
-                }
-            }
-        }
-
-        Err(e) => {
-            response_tx
-                .send(Err(BallistaError::General(format!("{:?}", e))))
-                .await
-                .unwrap();
-        }
-    }
-
-    println!(
-        "ParquetScan scanned {} batches and {} rows containing {} bytes in {} ms. Total duration {} ms.",
-        output_batches,
-        output_rows,
-        total_bytes_read,
-        batch_read_time,
-        start.elapsed().as_millis()
-    );
-}
-
-#[async_trait]
 impl ColumnarBatchIter for ParquetBatchIter {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
 
     fn next(&self) -> Result<Option<ColumnarBatch>> {
-        let x = self.response_rx.clone();
-        smol::run(async { x.recv().await.unwrap() })
+        let mut ref_mut = self.batch_reader.borrow_mut();
+        match ref_mut.next_batch().unwrap() {
+            Some(batch) => Ok(Some(ColumnarBatch::from_arrow(&batch))),
+            None => Ok(None),
+        }
     }
 }

--- a/rust/ballista/src/execution/operators/parquet_scan.rs
+++ b/rust/ballista/src/execution/operators/parquet_scan.rs
@@ -132,7 +132,7 @@ impl ParquetBatchIter {
         let file_reader = Rc::new(SerializedFileReader::new(file).unwrap()); //TODO error handling
         let mut arrow_reader = ParquetFileArrowReader::new(file_reader);
         let batch_reader = arrow_reader
-            .get_record_reader_by_columns(projection.clone(), batch_size)
+            .get_record_reader_by_columns(projection, batch_size)
             .unwrap();
 
         Ok(Self {

--- a/rust/ballista/src/execution/operators/projection.rs
+++ b/rust/ballista/src/execution/operators/projection.rs
@@ -107,8 +107,8 @@ impl ColumnarBatchIter for ProjectionIter {
         self.schema.clone()
     }
 
-    async fn next(&self) -> Result<Option<ColumnarBatch>> {
-        match self.input.next().await? {
+    fn next(&self) -> Result<Option<ColumnarBatch>> {
+        match self.input.next()? {
             Some(batch) => {
                 let projected_values: Vec<ColumnarValue> = self
                     .projection

--- a/rust/ballista/src/execution/operators/projection.rs
+++ b/rust/ballista/src/execution/operators/projection.rs
@@ -101,7 +101,6 @@ struct ProjectionIter {
     schema: Arc<Schema>,
 }
 
-#[async_trait]
 impl ColumnarBatchIter for ProjectionIter {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -61,8 +61,7 @@ pub struct ExecutorMeta {
 }
 
 /// Async iterator over a stream of columnar batches
-#[async_trait]
-pub trait ColumnarBatchIter: Sync + Send {
+pub trait ColumnarBatchIter {
     /// Get the schema for the batches produced by this iterator.
     fn schema(&self) -> Arc<Schema>;
 

--- a/rust/ballista/src/execution/physical_plan.rs
+++ b/rust/ballista/src/execution/physical_plan.rs
@@ -67,11 +67,11 @@ pub trait ColumnarBatchIter: Sync + Send {
     fn schema(&self) -> Arc<Schema>;
 
     /// Get the next batch from the stream, or None if the stream has ended
-    async fn next(&self) -> Result<Option<ColumnarBatch>>;
+    fn next(&self) -> Result<Option<ColumnarBatch>>;
 
     /// Notify the iterator that no more results will be fetched, so that resources
     /// can be freed immediately.
-    async fn close(&self) {}
+    fn close(&self) {}
 }
 
 #[async_trait]

--- a/rust/ballista/src/serde/from_proto.rs
+++ b/rust/ballista/src/serde/from_proto.rs
@@ -416,7 +416,6 @@ impl TryInto<PhysicalPlan> for &protobuf::PhysicalPlanNode {
                         scan.filename.clone(),
                         Some(scan.projection.iter().map(|n| *n as usize).collect()),
                         scan.batch_size as usize,
-                        scan.queue_size as usize,
                     )?,
                 ))),
                 other => Err(ballista_error(&format!(

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -420,7 +420,6 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                     schema: Some(exec.original_schema().as_ref().try_into()?),
                     has_header: exec.has_header,
                     batch_size: exec.batch_size as u32,
-                    queue_size: 0,
                 });
                 Ok(node)
             }
@@ -445,7 +444,6 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                     schema: None,
                     has_header: false,
                     batch_size: exec.batch_size as u32,
-                    queue_size: exec.queue_size as u32,
                 });
                 Ok(node)
             }

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -435,6 +435,8 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                     filename: exec.filenames.clone(),
                     projection: exec
                         .projection
+                        .as_ref()
+                        .unwrap()
                         .iter()
                         .map(|n| *n as u32)
                         .collect(),

--- a/rust/ballista/src/serde/to_proto.rs
+++ b/rust/ballista/src/serde/to_proto.rs
@@ -435,8 +435,6 @@ impl TryInto<protobuf::PhysicalPlanNode> for &PhysicalPlan {
                     filename: exec.filenames.clone(),
                     projection: exec
                         .projection
-                        .as_ref()
-                        .unwrap()
                         .iter()
                         .map(|n| *n as u32)
                         .collect(),

--- a/rust/ballista/tests/query_execution.rs
+++ b/rust/ballista/tests/query_execution.rs
@@ -76,7 +76,7 @@ async fn execute(use_filter: bool) {
     let start = Instant::now();
     let stream: ColumnarBatchStream = hash_agg.as_execution_plan().execute(ctx, 0).await.unwrap();
     let mut results = vec![];
-    while let Some(batch) = stream.next().await.unwrap() {
+    while let Some(batch) = stream.next().unwrap() {
         results.push(batch);
     }
 

--- a/rust/examples/tpch/src/main.rs
+++ b/rust/examples/tpch/src/main.rs
@@ -137,27 +137,34 @@ async fn q1(ctx: &Context, path: &str, format: &FileFormat) -> Result<Vec<Record
 
     let df = input
         .filter(col("l_shipdate").lt(&lit_str("1998-09-01")))? // should be l_shipdate <= date '1998-12-01' - interval ':1' day (3)
-        .project(vec![
-            col("l_returnflag"),
-            col("l_linestatus"),
-            col("l_quantity"),
-            col("l_extendedprice"),
-            col("l_tax"),
-            col("l_discount"),
-            mult(
-                &col("l_extendedprice"),
-                &subtract(&lit_f64(1_f64), &col("l_discount")),
-            )
-            .alias("disc_price"),
-        ])?
+        // .project(vec![
+        //     col("l_returnflag"),
+        //     col("l_linestatus"),
+        //     col("l_quantity"),
+        //     col("l_extendedprice"),
+        //     col("l_tax"),
+        //     col("l_discount"),
+        //     mult(
+        //         &col("l_extendedprice"),
+        //         &subtract(&lit_f64(1_f64), &col("l_discount")),
+        //     )
+        //     .alias("disc_price"),
+        // ])?
         .aggregate(
             vec![col("l_returnflag"), col("l_linestatus")],
             vec![
                 sum(col("l_quantity")).alias("sum_qty"),
                 sum(col("l_extendedprice")).alias("sum_base_price"),
-                sum(col("disc_price")).alias("sum_disc_price"),
                 sum(mult(
-                    &col("disc_price"),
+                    &col("l_extendedprice"),
+                    &subtract(&lit_f64(1_f64), &col("l_discount")),
+                ))
+                .alias("sum_disc_price"),
+                sum(mult(
+                    &mult(
+                        &col("l_extendedprice"),
+                        &subtract(&lit_f64(1_f64), &col("l_discount")),
+                    ),
                     &add(&lit_f64(1_f64), &col("l_tax")),
                 ))
                 .alias("sum_charge"),

--- a/rust/examples/tpch/src/main.rs
+++ b/rust/examples/tpch/src/main.rs
@@ -73,7 +73,6 @@ async fn main() -> Result<()> {
 
     let mut settings = HashMap::new();
     settings.insert(PARQUET_READER_BATCH_SIZE, "65536");
-    settings.insert(PARQUET_READER_QUEUE_SIZE, "2");
 
     let ctx = Context::remote(executor_host, executor_port, settings);
 


### PR DESCRIPTION
Remove `async` from `ColumnBatchIter` so we can remove the separate threads for parquet scans.