### PR TITLE
Add CLI to Spark benchmark

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -2,8 +2,21 @@
 
 This project contains:
 
-- Ballista Spark Executor
-- Spark V2 Connector for Ballista
+- Spark benchmarks and utilities for TPC-H and NYC Taxi
+- Ballista Spark Executor (prototype)
+- Spark V2 Connector for Ballista (prototype)
+
+## Build
+
+```bash
+./gradlew assemble
+```
+
+## Build Benchmark Docker Image
+
+```bash
+docker build -t ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT -f benchmarks/Dockerfile .
+```
 
 ## Ballista Spark Executor
 
@@ -13,4 +26,31 @@ Executor implementing the Ballista protocol (Apache Flight + protobuf-encoded Ba
 
 The goal for this component is to allow Spark to interact with Ballista executors (Rust, Kotlin, and Spark executors exist).
 
+## Running benchmarks on k8s
 
+# Ballista Spark Benchmarks
+
+## Prerequisites
+
+Follow instructions at http://spark.apache.org/docs/latest/running-on-kubernetes.html
+
+Relies on rbac and pv from top-level kubernetes dir in this repo
+
+## Build Jars
+
+```bash
+./gradlew assemble
+```
+
+## Build Docker Image
+
+```bash
+docker build -t ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT .
+```
+
+## Deploy
+
+```bash
+export SPARK_HOME=/path/to/spark-3.0.0-bin-hadoop3.2
+./run-tpch-k8s.sh
+```

--- a/spark/benchmarks/Dockerfile
+++ b/spark/benchmarks/Dockerfile
@@ -1,7 +1,5 @@
 FROM ballistacompute/spark:3.0.0
-
 USER root
-
-RUN mkdir -p /opt/ballista/jars
-
-ADD build/libs/benchmarks.jar /opt/ballista/jars/
+ADD benchmarks/build/distributions/benchmarks.tar /opt/
+ENTRYPOINT [ "/opt/benchmarks/bin/benchmarks" ]
+CMD [ "--help" ]

--- a/spark/benchmarks/README.md
+++ b/spark/benchmarks/README.md
@@ -1,27 +1,2 @@
-# Ballista Spark Benchmarks
 
-## Prerequisites
-
-Follow instructions at http://spark.apache.org/docs/latest/running-on-kubernetes.html
-
-Relies on rbac and pv from top-level kubernetes dir in this repo
-
-## Build Jars
-
-```bash
-./gradlew assemble
-```
-
-## Build Docker Image
-
-```bash
-docker build -t ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT .
-```
-
-## Deploy
-
-```bash
-export SPARK_HOME=/path/to/spark-3.0.0-bin-hadoop3.2
-./run-tpch-k8s.sh
-```
 

--- a/spark/benchmarks/src/main/scala/org/ballistacompute/spark/benchmarks/tpch/Tpch.scala
+++ b/spark/benchmarks/src/main/scala/org/ballistacompute/spark/benchmarks/tpch/Tpch.scala
@@ -1,68 +1,31 @@
 package org.ballistacompute.spark.benchmarks.tpch
 
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
-import org.apache.spark.sql.{SaveMode, SparkSession}
 
 object Tpch {
 
-  def main(arg: Array[String]): Unit = {
+  val LINEITEM_SCHEMA = new StructType(Array(
+    StructField("l_orderkey", DataTypes.IntegerType, true),
+    StructField("l_partkey", DataTypes.IntegerType, true),
+    StructField("l_suppkey", DataTypes.IntegerType, true),
+    StructField("l_linenumber", DataTypes.IntegerType, true),
+    StructField("l_quantity", DataTypes.DoubleType, true),
+    StructField("l_extendedprice", DataTypes.DoubleType, true),
+    StructField("l_discount", DataTypes.DoubleType, true),
+    StructField("l_tax", DataTypes.DoubleType, true),
+    StructField("l_returnflag", DataTypes.StringType, true),
+    StructField("l_linestatus", DataTypes.StringType, true),
+    StructField("l_shipdate", DataTypes.StringType, true),
+    StructField("l_commitdate", DataTypes.StringType, true),
+    StructField("l_receiptdate", DataTypes.StringType, true),
+    StructField("l_shipinstruct", DataTypes.StringType, true),
+    StructField("l_shipmode", DataTypes.StringType, true),
+    StructField("l_comment", DataTypes.StringType, true)
+  ))
 
-    val spark: SparkSession = SparkSession.builder
-      .appName(this.getClass.getName)
-      .master("local[48]")
-      .getOrCreate()
-
-    q1(spark)
-  }
-
-  def repartition(n: Int) {
-
-    val spark: SparkSession = SparkSession.builder
-      .appName(this.getClass.getName)
-      .master("local[1]")
-      .getOrCreate()
-
-      spark.read.parquet("/mnt/tpch/parquet/10/lineitem")
-      .repartition(n)
-      .write
-      .parquet(s"./tmp-$n")
-  }
-
-  def adhoc(): Unit = {
-
-    val spark: SparkSession = SparkSession.builder
-      .appName(this.getClass.getName)
-      .master("local[24]")
-      .getOrCreate()
-
-    spark.time {
-
-      spark.read.parquet("/mnt/tpch/parquet/10-24/lineitem").createOrReplaceTempView("lineitem")
-
-      val df = spark.sql(
-        """
-          | select
-          |     l_shipdate, count(*) as n
-          | from
-          |     lineitem
-          | group by
-          |     l_shipdate
-          | order by l_shipdate desc limit 10
-          |""".stripMargin)
-
-      df.show()
-      df.explain()
-    }
-
-  }
-
-  def q1(spark: SparkSession): Unit = {
-
-    spark.time {
-
-      spark.read.parquet("/mnt/tpch/parquet/100-240/lineitem").createOrReplaceTempView("lineitem")
-
-      val df = spark.sql(
+  def query(name: String) : String = {
+    name match {
+      case "q1" =>
         """
           | select
           |     l_returnflag,
@@ -82,50 +45,11 @@ object Tpch {
           | group by
           |     l_returnflag,
           |     l_linestatus
-          |""".stripMargin)
+          |""".stripMargin
 
-      df.show()
-      df.explain()
+      case _ =>
+        throw new IllegalArgumentException(s"No query named '$name'")
     }
   }
 
-  def convertToParquet(csvPath: String, parquetPath: String) {
-
-    val spark: SparkSession = SparkSession.builder
-      .appName(this.getClass.getName)
-      .master("local[*]")
-      .getOrCreate()
-
-    val df = spark.read
-      .option("header", "false")
-      .option("inferSchema", "false")
-      .option("delimiter", "|")
-      .schema(new StructType(Array(
-        StructField("l_orderkey", DataTypes.IntegerType, true),
-        StructField("l_partkey", DataTypes.IntegerType, true),
-        StructField("l_suppkey", DataTypes.IntegerType, true),
-        StructField("l_linenumber", DataTypes.IntegerType, true),
-        StructField("l_quantity", DataTypes.DoubleType, true),
-        StructField("l_extendedprice", DataTypes.DoubleType, true),
-        StructField("l_discount", DataTypes.DoubleType, true),
-        StructField("l_tax", DataTypes.DoubleType, true),
-        StructField("l_returnflag", DataTypes.StringType, true),
-        StructField("l_linestatus", DataTypes.StringType, true),
-        StructField("l_shipdate", DataTypes.StringType, true),
-        StructField("l_commitdate", DataTypes.StringType, true),
-        StructField("l_receiptdate", DataTypes.StringType, true),
-        StructField("l_shipinstruct", DataTypes.StringType, true),
-        StructField("l_shipmode", DataTypes.StringType, true),
-        StructField("l_comment", DataTypes.StringType, true),
-      )))
-      .csv(csvPath)
-
-    df.coalesce(1)
-      .write
-      .mode(SaveMode.Overwrite)
-      .parquet(parquetPath)
-
-    df.printSchema()
-
-  }
 }


### PR DESCRIPTION
This PR simply adds a CLI to the Spark benchmark code and removes the hard-coded ad-hoc code that I had been running manually from my IDE. It also updates the Docker packaging so that others can run the benchmarks and TPC-H file conversion by just pulling the published Docker image.