### PR TITLE
unit test for serde of logical plan

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "sqlparser",
  "tokio",
  "tonic",
 ]

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -13,6 +13,7 @@ include = ["build.rs", "src/**/*", "Cargo.toml", "proto/ballista.proto"]
 [dependencies]
 prost = "0.6"
 prost-types = "0.6"
+sqlparser = "0.7"
 tokio = { version = "0.2", features = ["full"] }
 tonic = "0.2"
 

--- a/rust/ballista/src/error.rs
+++ b/rust/ballista/src/error.rs
@@ -19,8 +19,8 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::result;
 
-use crate::arrow::error::ArrowError;
-use crate::datafusion::error::ExecutionError;
+use arrow::error::ArrowError;
+use datafusion::error::DataFusionError;
 use sqlparser::parser;
 
 pub type Result<T> = result::Result<T, BallistaError>;
@@ -31,14 +31,14 @@ pub enum BallistaError {
     NotImplemented(String),
     General(String),
     ArrowError(ArrowError),
-    DataFusionError(ExecutionError),
+    DataFusionError(DataFusionError),
     SqlError(parser::ParserError),
     IoError(io::Error),
-    ReqwestError(reqwest::Error),
-    HttpError(http::Error),
-    KubeAPIError(kube::error::Error),
-    KubeAPIRequestError(k8s_openapi::RequestError),
-    KubeAPIResponseError(k8s_openapi::ResponseError),
+    // ReqwestError(reqwest::Error),
+    //HttpError(http::Error),
+    // KubeAPIError(kube::error::Error),
+    // KubeAPIRequestError(k8s_openapi::RequestError),
+    // KubeAPIResponseError(k8s_openapi::ResponseError),
     // TonicError(tonic::status::Status)
 }
 
@@ -64,8 +64,8 @@ impl From<parser::ParserError> for BallistaError {
     }
 }
 
-impl From<ExecutionError> for BallistaError {
-    fn from(e: ExecutionError) -> Self {
+impl From<DataFusionError> for BallistaError {
+    fn from(e: DataFusionError) -> Self {
         BallistaError::DataFusionError(e)
     }
 }
@@ -76,35 +76,35 @@ impl From<io::Error> for BallistaError {
     }
 }
 
-impl From<reqwest::Error> for BallistaError {
-    fn from(e: reqwest::Error) -> Self {
-        BallistaError::ReqwestError(e)
-    }
-}
-
-impl From<http::Error> for BallistaError {
-    fn from(e: http::Error) -> Self {
-        BallistaError::HttpError(e)
-    }
-}
-
-impl From<kube::error::Error> for BallistaError {
-    fn from(e: kube::error::Error) -> Self {
-        BallistaError::KubeAPIError(e)
-    }
-}
-
-impl From<k8s_openapi::RequestError> for BallistaError {
-    fn from(e: k8s_openapi::RequestError) -> Self {
-        BallistaError::KubeAPIRequestError(e)
-    }
-}
-
-impl From<k8s_openapi::ResponseError> for BallistaError {
-    fn from(e: k8s_openapi::ResponseError) -> Self {
-        BallistaError::KubeAPIResponseError(e)
-    }
-}
+// impl From<reqwest::Error> for BallistaError {
+//     fn from(e: reqwest::Error) -> Self {
+//         BallistaError::ReqwestError(e)
+//     }
+// }
+//
+// impl From<http::Error> for BallistaError {
+//     fn from(e: http::Error) -> Self {
+//         BallistaError::HttpError(e)
+//     }
+// }
+//
+// impl From<kube::error::Error> for BallistaError {
+//     fn from(e: kube::error::Error) -> Self {
+//         BallistaError::KubeAPIError(e)
+//     }
+// }
+//
+// impl From<k8s_openapi::RequestError> for BallistaError {
+//     fn from(e: k8s_openapi::RequestError) -> Self {
+//         BallistaError::KubeAPIRequestError(e)
+//     }
+// }
+//
+// impl From<k8s_openapi::ResponseError> for BallistaError {
+//     fn from(e: k8s_openapi::ResponseError) -> Self {
+//         BallistaError::KubeAPIResponseError(e)
+//     }
+// }
 
 // impl From<tonic::status::Status> for BallistaError {
 //     fn from(e: tonic::status::Status) -> Self {
@@ -121,15 +121,15 @@ impl Display for BallistaError {
             BallistaError::DataFusionError(ref desc) => write!(f, "DataFusion error: {:?}", desc),
             BallistaError::SqlError(ref desc) => write!(f, "SQL error: {:?}", desc),
             BallistaError::IoError(ref desc) => write!(f, "IO error: {}", desc),
-            BallistaError::ReqwestError(ref desc) => write!(f, "Reqwest error: {}", desc),
-            BallistaError::HttpError(ref desc) => write!(f, "HTTP error: {}", desc),
-            BallistaError::KubeAPIError(ref desc) => write!(f, "Kube API error: {}", desc),
-            BallistaError::KubeAPIRequestError(ref desc) => {
-                write!(f, "KubeAPI request error: {}", desc)
-            }
-            BallistaError::KubeAPIResponseError(ref desc) => {
-                write!(f, "KubeAPI response error: {}", desc)
-            }
+            // BallistaError::ReqwestError(ref desc) => write!(f, "Reqwest error: {}", desc),
+            // BallistaError::HttpError(ref desc) => write!(f, "HTTP error: {}", desc),
+            // BallistaError::KubeAPIError(ref desc) => write!(f, "Kube API error: {}", desc),
+            // BallistaError::KubeAPIRequestError(ref desc) => {
+            //     write!(f, "KubeAPI request error: {}", desc)
+            // }
+            // BallistaError::KubeAPIResponseError(ref desc) => {
+            //     write!(f, "KubeAPI response error: {}", desc)
+            // }
         }
     }
 }

--- a/rust/ballista/src/lib.rs
+++ b/rust/ballista/src/lib.rs
@@ -14,4 +14,5 @@
 
 //! Serialization code for translating between query plans and protobuf
 
+pub mod error;
 pub mod serde;

--- a/rust/ballista/src/serde/logical_plan/from_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/from_proto.rs
@@ -17,7 +17,7 @@
 use std::convert::TryInto;
 
 use crate::serde::proto_error;
-use crate::serde::{protobuf, BallistaProtoError};
+use crate::serde::{protobuf, BallistaError};
 
 use arrow::datatypes::{DataType, Field, Schema};
 use datafusion::logical_plan::{Expr, LogicalPlan, LogicalPlanBuilder, Operator};
@@ -48,7 +48,7 @@ macro_rules! convert_box_required {
 }
 
 impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<LogicalPlan, Self::Error> {
         if let Some(projection) = &self.projection {
@@ -124,7 +124,7 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
 }
 
 impl TryInto<Expr> for &protobuf::LogicalExprNode {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<Expr, Self::Error> {
         if let Some(binary_expr) = &self.binary_expr {
@@ -205,7 +205,7 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
 }
 
 // impl TryInto<Action> for &protobuf::Action {
-//     type Error = BallistaProtoError;
+//     type Error = BallistaError;
 //
 //     fn try_into(self) -> Result<Action, Self::Error> {
 //         if self.query.is_some() {
@@ -222,7 +222,7 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
 //             let shuffle_id: ShuffleId = convert_required!(self.fetch_shuffle)?;
 //             Ok(Action::FetchShuffle(shuffle_id))
 //         } else {
-//             Err(BallistaProtoError::NotImplemented(format!(
+//             Err(BallistaError::NotImplemented(format!(
 //                 "from_proto(Action) {:?}",
 //                 self
 //             )))
@@ -230,7 +230,7 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
 //     }
 // }
 
-fn from_proto_binary_op(op: &str) -> Result<Operator, BallistaProtoError> {
+fn from_proto_binary_op(op: &str) -> Result<Operator, BallistaError> {
     match op {
         "Eq" => Ok(Operator::Eq),
         "NotEq" => Ok(Operator::NotEq),
@@ -249,7 +249,7 @@ fn from_proto_binary_op(op: &str) -> Result<Operator, BallistaProtoError> {
     }
 }
 
-fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaProtoError> {
+fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaError> {
     match dt {
         dt if dt == protobuf::ArrowType::Uint8 as i32 => Ok(DataType::UInt8),
         dt if dt == protobuf::ArrowType::Int8 as i32 => Ok(DataType::Int8),
@@ -262,7 +262,7 @@ fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaProtoError> {
         dt if dt == protobuf::ArrowType::Float as i32 => Ok(DataType::Float32),
         dt if dt == protobuf::ArrowType::Double as i32 => Ok(DataType::Float64),
         dt if dt == protobuf::ArrowType::Utf8 as i32 => Ok(DataType::Utf8),
-        other => Err(BallistaProtoError::General(format!(
+        other => Err(BallistaError::General(format!(
             "Unsupported data type {:?}",
             other
         ))),
@@ -270,7 +270,7 @@ fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaProtoError> {
 }
 
 // impl TryInto<ExecutionTask> for &protobuf::Task {
-//     type Error = BallistaProtoError;
+//     type Error = BallistaError;
 //
 //     fn try_into(self) -> Result<ExecutionTask, Self::Error> {
 //         let mut shuffle_locations: HashMap<ShuffleId, ExecutorMeta> = HashMap::new();
@@ -301,7 +301,7 @@ fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaProtoError> {
 // }
 //
 // impl TryInto<ShuffleLocation> for &protobuf::ShuffleLocation {
-//     type Error = BallistaProtoError;
+//     type Error = BallistaError;
 //
 //     fn try_into(self) -> Result<ShuffleLocation, Self::Error> {
 //         Ok(ShuffleLocation {}) //TODO why empty?
@@ -309,7 +309,7 @@ fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaProtoError> {
 // }
 //
 // impl TryInto<ShuffleId> for &protobuf::ShuffleId {
-//     type Error = BallistaProtoError;
+//     type Error = BallistaError;
 //
 //     fn try_into(self) -> Result<ShuffleId, Self::Error> {
 //         Ok(ShuffleId::new(
@@ -321,7 +321,7 @@ fn from_proto_arrow_type(dt: i32) -> Result<DataType, BallistaProtoError> {
 // }
 
 impl TryInto<Schema> for &protobuf::Schema {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<Schema, Self::Error> {
         let fields = self
@@ -337,7 +337,7 @@ impl TryInto<Schema> for &protobuf::Schema {
 }
 
 // impl TryInto<PhysicalPlan> for &protobuf::PhysicalPlanNode {
-//     type Error = BallistaProtoError;
+//     type Error = BallistaError;
 //
 //     fn try_into(self) -> Result<PhysicalPlan, Self::Error> {
 //         if let Some(selection) = &self.selection {
@@ -444,9 +444,7 @@ impl TryInto<Schema> for &protobuf::Schema {
 //     }
 // }
 
-fn parse_required_expr(
-    p: &Option<Box<protobuf::LogicalExprNode>>,
-) -> Result<Expr, BallistaProtoError> {
+fn parse_required_expr(p: &Option<Box<protobuf::LogicalExprNode>>) -> Result<Expr, BallistaError> {
     match p {
         Some(expr) => expr.as_ref().try_into(),
         None => Err(proto_error("Missing required expression")),

--- a/rust/ballista/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/to_proto.rs
@@ -18,7 +18,7 @@
 
 use std::convert::TryInto;
 
-use crate::serde::{empty_expr_node, empty_logical_plan_node, protobuf, BallistaProtoError};
+use crate::serde::{empty_expr_node, empty_logical_plan_node, protobuf, BallistaError};
 
 use arrow::datatypes::{DataType, Schema};
 use datafusion::datasource::parquet::ParquetTable;
@@ -28,7 +28,7 @@ use datafusion::physical_plan::aggregates::AggregateFunction;
 use datafusion::scalar::ScalarValue;
 
 impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<protobuf::LogicalPlanNode, Self::Error> {
         match self {
@@ -78,7 +78,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                     });
                     Ok(node)
                 } else {
-                    Err(BallistaProtoError::General(format!(
+                    Err(BallistaError::General(format!(
                         "logical plan to_proto unsupported table provider {:?}",
                         source
                     )))
@@ -92,7 +92,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                     expr: expr
                         .iter()
                         .map(|expr| expr.try_into())
-                        .collect::<Result<Vec<_>, BallistaProtoError>>()?,
+                        .collect::<Result<Vec<_>, BallistaError>>()?,
                 });
                 Ok(node)
             }
@@ -118,11 +118,11 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                     group_expr: group_expr
                         .iter()
                         .map(|expr| expr.try_into())
-                        .collect::<Result<Vec<_>, BallistaProtoError>>()?,
+                        .collect::<Result<Vec<_>, BallistaError>>()?,
                     aggr_expr: aggr_expr
                         .iter()
                         .map(|expr| expr.try_into())
-                        .collect::<Result<Vec<_>, BallistaProtoError>>()?,
+                        .collect::<Result<Vec<_>, BallistaError>>()?,
                 });
                 Ok(node)
             }
@@ -165,7 +165,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
             LogicalPlan::CreateExternalTable { .. } => unimplemented!(),
             LogicalPlan::Explain { .. } => unimplemented!(),
             LogicalPlan::Extension { .. } => unimplemented!(),
-            // _ => Err(BallistaProtoError::General(format!(
+            // _ => Err(BallistaError::General(format!(
             //     "logical plan to_proto {:?}",
             //     self
             // ))),
@@ -174,7 +174,7 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
 }
 
 impl TryInto<protobuf::LogicalExprNode> for &Expr {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<protobuf::LogicalExprNode, Self::Error> {
         match self {
@@ -259,7 +259,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                     expr.literal_f64 = n.unwrap() as f64; // TODO remove unwrap
                     Ok(expr)
                 }
-                other => Err(BallistaProtoError::General(format!(
+                other => Err(BallistaError::General(format!(
                     "to_proto unsupported scalar value {:?}",
                     other
                 ))),
@@ -307,7 +307,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
             Expr::Sort { .. } => unimplemented!(),
             Expr::InList { .. } => unimplemented!(),
             Expr::Wildcard => unimplemented!(),
-            // _ => Err(BallistaProtoError::General(format!(
+            // _ => Err(BallistaError::General(format!(
             //     "logical expr to_proto {:?}",
             //     self
             // ))),
@@ -316,7 +316,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
 }
 
 impl TryInto<protobuf::Schema> for &Schema {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<protobuf::Schema, Self::Error> {
         Ok(protobuf::Schema {
@@ -337,7 +337,7 @@ impl TryInto<protobuf::Schema> for &Schema {
     }
 }
 
-fn to_proto_arrow_type(dt: &DataType) -> Result<protobuf::ArrowType, BallistaProtoError> {
+fn to_proto_arrow_type(dt: &DataType) -> Result<protobuf::ArrowType, BallistaError> {
     match dt {
         DataType::Int8 => Ok(protobuf::ArrowType::Int8),
         DataType::Int16 => Ok(protobuf::ArrowType::Int16),
@@ -350,7 +350,7 @@ fn to_proto_arrow_type(dt: &DataType) -> Result<protobuf::ArrowType, BallistaPro
         DataType::Float32 => Ok(protobuf::ArrowType::Float),
         DataType::Float64 => Ok(protobuf::ArrowType::Double),
         DataType::Utf8 => Ok(protobuf::ArrowType::Utf8),
-        other => Err(BallistaProtoError::General(format!(
+        other => Err(BallistaError::General(format!(
             "Unsupported data type {:?}",
             other
         ))),

--- a/rust/ballista/src/serde/physical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/physical_plan/to_proto.rs
@@ -19,7 +19,7 @@
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
-use crate::serde::{empty_expr_node, empty_physical_plan_node, protobuf, BallistaProtoError};
+use crate::serde::{empty_expr_node, empty_physical_plan_node, protobuf, BallistaError};
 
 use datafusion::physical_plan::csv::CsvExec;
 use datafusion::physical_plan::expressions::{
@@ -35,7 +35,7 @@ use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 
 impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_into(self) -> Result<protobuf::PhysicalPlanNode, Self::Error> {
         let plan = self.as_any();
@@ -144,7 +144,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
         //         Ok(node)
         //     }
         } else {
-            Err(BallistaProtoError::General(format!(
+            Err(BallistaError::General(format!(
                 "physical plan to_proto {:?}",
                 self
             )))
@@ -153,7 +153,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
 }
 
 impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::LogicalExprNode {
-    type Error = BallistaProtoError;
+    type Error = BallistaError;
 
     fn try_from(value: Arc<dyn PhysicalExpr>) -> Result<Self, Self::Error> {
         let expr = value.as_any();
@@ -191,7 +191,7 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::LogicalExprNode {
         } else if let Some(_expr) = expr.downcast_ref::<ScalarFunctionExpr>() {
             unimplemented!()
         } else {
-            Err(BallistaProtoError::General(format!(
+            Err(BallistaError::General(format!(
                 "unsupported physical expression {:?}",
                 value
             )))


### PR DESCRIPTION
The main goal of this PR is to add a unit test for round-trip serde for a simple logical plan.

Other changes made to support this:

- Ported the `error.rs` file from the original codebase
- Updated the serde code to use `BallistaError` instead of `BallistaProtoError`