### PR TITLE
Re-instate Rust executor

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "sqlparser",
+ "structopt",
  "tokio",
  "tonic",
 ]
@@ -1256,6 +1257,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1616,30 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3"
 prost = "0.6"
 prost-types = "0.6"
 sqlparser = "0.7"
+structopt = "0.3"
 tokio = { version = "0.2", features = ["full"] }
 tonic = "0.3"
 

--- a/rust/ballista/src/bin/executor.rs
+++ b/rust/ballista/src/bin/executor.rs
@@ -14,48 +14,44 @@
 
 //! Ballista Rust executor binary.
 
-// use std::sync::Arc;
-//
-// use ballista::arrow_flight::flight_service_server::FlightServiceServer;
-// use ballista::distributed::executor::{BallistaExecutor, DiscoveryMode, Executor, ExecutorConfig};
-// use ballista::distributed::flight_service::BallistaFlightService;
-// use ballista::distributed::scheduler::{BallistaScheduler, Scheduler};
-// use ballista::BALLISTA_VERSION;
-//
-// use structopt::StructOpt;
-// use tonic::transport::Server;
-//
-// /// A basic example
-// #[derive(StructOpt, Debug)]
-// #[structopt(name = "basic")]
-// struct Opt {
-//     /// discovery mode
-//     #[structopt(short, long)]
-//     mode: Option<String>,
-//
-//     /// etcd urls for use when discovery mode is `etcd`
-//     #[structopt(long)]
-//     etcd_urls: Option<String>,
-//
-//     #[structopt(long)]
-//     bind_host: Option<String>,
-//
-//     #[structopt(long)]
-//     external_host: Option<String>,
-//
-//     /// bind port
-//     #[structopt(short, long)]
-//     port: usize,
-//
-//     /// max concurrent tasks
-//     #[structopt(short, long)]
-//     concurrent_tasks: usize,
-// }
+use arrow_flight::flight_service_server::FlightServiceServer;
+use ballista::flight_service::BallistaFlightService;
+use ballista::BALLISTA_VERSION;
+
+use structopt::StructOpt;
+use tonic::transport::Server;
+
+/// A basic example
+#[derive(StructOpt, Debug)]
+#[structopt(name = "basic")]
+struct Opt {
+    /// discovery mode
+    #[structopt(short, long)]
+    mode: Option<String>,
+
+    /// etcd urls for use when discovery mode is `etcd`
+    #[structopt(long)]
+    etcd_urls: Option<String>,
+
+    #[structopt(long)]
+    bind_host: Option<String>,
+
+    #[structopt(long)]
+    external_host: Option<String>,
+
+    /// bind port
+    #[structopt(short, long, default_value = "8000")]
+    port: usize,
+
+    /// max concurrent tasks
+    #[structopt(short, long, default_value = "4")]
+    concurrent_tasks: usize,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // let opt = Opt::from_args();
-    //
+    let opt = Opt::from_args();
+
     // let mode = match opt.mode {
     //     Some(s) => match s.as_str() {
     //         "k8s" => DiscoveryMode::Kubernetes,
@@ -64,29 +60,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     },
     //     _ => DiscoveryMode::Standalone,
     // };
-    //
-    // let external_host = opt.external_host.unwrap_or_else(|| "localhost".to_owned());
-    // let bind_host = opt.bind_host.unwrap_or_else(|| "0.0.0.0".to_owned());
-    // let etcd_urls = opt.etcd_urls.unwrap_or_else(|| "localhost:2379".to_owned());
-    // let port = opt.port;
-    //
+
+    let _external_host = opt.external_host.unwrap_or_else(|| "localhost".to_owned());
+    let bind_host = opt.bind_host.unwrap_or_else(|| "0.0.0.0".to_owned());
+    let _etcd_urls = opt.etcd_urls.unwrap_or_else(|| "localhost:2379".to_owned());
+    let port = opt.port;
+
     // let config = ExecutorConfig::new(mode, &external_host, port, &etcd_urls, opt.concurrent_tasks);
-    //
     // println!("Running with config: {:?}", config);
-    //
-    // let addr = format!("{}:{}", bind_host, port);
-    // let addr = addr.parse()?;
-    //
-    // // TODO split scheduler and executor into separate processes soon
+
+    let addr = format!("{}:{}", bind_host, port);
+    let addr = addr.parse()?;
+
+    // TODO split scheduler and executor into separate processes soon
     // let scheduler: Arc<dyn Scheduler> = Arc::new(BallistaScheduler::new(config.clone()));
     // let executor: Arc<dyn Executor> = Arc::new(BallistaExecutor::new(config));
-    //
-    // let service = BallistaFlightService::new(scheduler, executor);
-    // let server = FlightServiceServer::new(service);
-    // println!(
-    //     "Ballista v{} Rust Executor listening on {:?}",
-    //     BALLISTA_VERSION, addr
-    // );
-    // Server::builder().add_service(server).serve(addr).await?;
+
+    let service = BallistaFlightService {}; //::new(/*scheduler, executor*/);
+    let server = FlightServiceServer::new(service);
+    println!(
+        "Ballista v{} Rust Executor listening on {:?}",
+        BALLISTA_VERSION, addr
+    );
+    Server::builder().add_service(server).serve(addr).await?;
     Ok(())
 }

--- a/rust/ballista/src/lib.rs
+++ b/rust/ballista/src/lib.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Serialization code for translating between query plans and protobuf
+//! Ballista Distributed Compute
+
+pub const BALLISTA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod error;
 pub mod flight_service;

--- a/rust/ballista/src/serde/mod.rs
+++ b/rust/ballista/src/serde/mod.rs
@@ -23,8 +23,6 @@ use crate::serde::scheduler::Action as BallistaAction;
 
 use prost::Message;
 
-pub const BALLISTA_PROTO_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 // include the generated protobuf source as a submodule
 #[allow(clippy::all)]
 pub mod protobuf {


### PR DESCRIPTION
The Rust executor runs again, but any requests will result in an error response.

```bash
cargo run --color=always --package ballista --bin executor
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/executor`
Ballista v0.4.0-SNAPSHOT Rust Executor listening on 0.0.0.0:8000
```