### PR TITLE
Port client from old code

### DIFF
--- a/rust/ballista/src/lib.rs
+++ b/rust/ballista/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub const BALLISTA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+pub mod client;
 pub mod error;
 pub mod flight_service;
 

--- a/rust/ballista/src/serde/scheduler/mod.rs
+++ b/rust/ballista/src/serde/scheduler/mod.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use datafusion::logical_plan::LogicalPlan;
 
 pub mod from_proto;
-// pub mod to_proto;
+pub mod to_proto;
 
 /// Action that can be sent to an executor
 #[derive(Debug, Clone)]

--- a/rust/ballista/src/serde/scheduler/to_proto.rs
+++ b/rust/ballista/src/serde/scheduler/to_proto.rs
@@ -1,0 +1,57 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::BallistaError;
+use crate::serde::protobuf;
+use crate::serde::scheduler::Action;
+use std::convert::TryInto;
+
+impl TryInto<protobuf::Action> for Action {
+    type Error = BallistaError;
+
+    fn try_into(self) -> Result<protobuf::Action, Self::Error> {
+        match self {
+            Action::InteractiveQuery { ref plan, settings } => {
+                let plan_proto: protobuf::LogicalPlanNode = plan.try_into()?;
+
+                let settings = settings
+                    .iter()
+                    .map(|e| protobuf::KeyValuePair {
+                        key: e.0.to_string(),
+                        value: e.1.to_string(),
+                    })
+                    .collect();
+
+                Ok(protobuf::Action {
+                    query: Some(plan_proto),
+                    task: None,
+                    fetch_shuffle: None,
+                    settings,
+                })
+            }
+            // Action::Execute(task) => Ok(protobuf::Action {
+            //     query: None,
+            //     task: Some(task.try_into()?),
+            //     fetch_shuffle: None,
+            //     settings: vec![],
+            // }),
+            // Action::FetchShuffle(shuffle_id) => Ok(protobuf::Action {
+            //     query: None,
+            //     task: None,
+            //     fetch_shuffle: Some(shuffle_id.try_into()?),
+            //     settings: vec![],
+            // }),
+        }
+    }
+}

--- a/rust/ballista/src/serde/scheduler/to_proto.rs
+++ b/rust/ballista/src/serde/scheduler/to_proto.rs
@@ -22,7 +22,7 @@ impl TryInto<protobuf::Action> for Action {
 
     fn try_into(self) -> Result<protobuf::Action, Self::Error> {
         match self {
-            Action::InteractiveQuery { ref plan, settings } => {
+            Action::InteractiveQuery { ref plan, ref settings } => {
                 let plan_proto: protobuf::LogicalPlanNode = plan.try_into()?;
 
                 let settings = settings


### PR DESCRIPTION
Adds client code that is capable of serializing a logical query plan and sending it to an executor and then receiving the results.