### PR TITLE
Implemented Serde for SortNode

### DIFF
--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -86,6 +86,7 @@ message LogicalPlanNode {
   LimitNode limit = 22;
   AggregateNode aggregate = 23;
   JoinNode join = 24;
+  SortNode sort = 25;
 }
 
 message ProjectionColumns {
@@ -117,6 +118,10 @@ message ProjectionNode {
 
 message SelectionNode {
   LogicalExprNode expr = 2;
+}
+
+message SortNode{
+    repeated LogicalExprNode expr = 1;
 }
 
 message AggregateNode {

--- a/rust/ballista/src/serde/logical_plan/from_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/from_proto.rs
@@ -114,7 +114,16 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
             LogicalPlanBuilder::scan_parquet(&scan.path, None, 24)? //TODO projection, concurrency
                 .build()
                 .map_err(|e| e.into())
-        } else {
+        } else if let Some(sort) = &self.sort {
+            let input: LogicalPlan = convert_box_required!(self.input)?;
+            let sort_expr: Vec<Expr> = sort.expr.iter()
+                                        .map(|expr| expr.try_into())
+                                        .collect::<Result<Vec<Expr>, _>>()?;
+            LogicalPlanBuilder::from(&input)
+                .sort(sort_expr)?
+                .build()
+                .map_err(|e| e.into())
+        }else {
             Err(proto_error(&format!(
                 "Unsupported logical plan '{:?}'",
                 self


### PR DESCRIPTION
Hi, I took a crack at implementing Serde for LogicalPlan::Sort. I assumed that ballista.proto needed to be changed, I'm not sure about the protobuf field numbering as there is the jump from one byte to 2 when exceeding 15 fields and I wasn't sure if the lower numbers were being reserved common node types. If this looks alright I'll take a crack at the other node types.