### PR TITLE
Logical plan node serde implementation

### DIFF
--- a/rust/ballista/build.rs
+++ b/rust/ballista/build.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn main() {
+fn main()->Result<(), String> {
+    println!("cargo:rerun-if-changed=proto/ballista.proto");
     prost_build::compile_protos(&["proto/ballista.proto"], &["proto"])
-        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+        .map_err(|e| format!("protobuf compilation failed: {}", e))
 }

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -86,6 +86,7 @@ message LogicalPlanNode {
   LimitNode limit = 22;
   AggregateNode aggregate = 23;
   JoinNode join = 24;
+  SortNode sort = 25;
 }
 
 message ProjectionColumns {
@@ -117,6 +118,10 @@ message ProjectionNode {
 
 message SelectionNode {
   LogicalExprNode expr = 2;
+}
+
+message SortNode{
+    repeated LogicalExprNode expr = 1;
 }
 
 message AggregateNode {

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -87,6 +87,10 @@ message LogicalPlanNode {
   AggregateNode aggregate = 23;
   JoinNode join = 24;
   SortNode sort = 25;
+  RepartitionNode repartition = 26;
+  EmptyRelationNode empty_relation = 27;
+  CreateExternalTableNode create_external_table = 28;
+  ExplainNode explain = 29;
 }
 
 message ProjectionColumns {
@@ -122,6 +126,45 @@ message SelectionNode {
 
 message SortNode{
     repeated LogicalExprNode expr = 1;
+}
+
+message RepartitionNode{
+    oneof partition_method{
+        uint64 round_robin = 1;
+        HashRepartition hash = 2;
+    }
+}
+
+message HashRepartition{
+    repeated LogicalExprNode hash_expr = 2;
+    uint64 batch_size = 1;
+}
+
+message EmptyRelationNode{
+    bool produce_one_row = 1;
+}
+
+message CreateExternalTableNode{
+    string name = 1;
+    string location = 2;
+    FileType file_type = 3;
+    bool has_header = 4;
+    Schema schema = 5;
+}
+
+enum FileType{
+    NdJson = 0;
+    Parquet = 1;
+    CSV = 2;
+}
+
+message ExplainNode{
+    bool verbose = 1;
+}
+ 
+message DfField{
+    string qualifier = 2;
+    Field field = 1;
 }
 
 message AggregateNode {

--- a/rust/ballista/src/serde/logical_plan/from_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/from_proto.rs
@@ -125,6 +125,56 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
                 .sort(sort_expr)?
                 .build()
                 .map_err(|e| e.into())
+            
+        }else if let Some(repartition) = &self.repartition{
+            use datafusion::logical_plan::Partitioning;
+            let input: LogicalPlan = convert_box_required!(self.input)?;
+            use protobuf::repartition_node::PartitionMethod;
+            let pb_partition_method = repartition.partition_method.clone()
+                                                                            .ok_or(
+                                                                                BallistaError::General(String::from("Protobuf deserialization error, RepartitionNode was missing required field 'partition_method'"))
+                                                                            )?;
+            
+
+            let partitioning_scheme = match pb_partition_method{
+                PartitionMethod::Hash(protobuf::HashRepartition{hash_expr: pb_hash_expr, batch_size})=>{
+                    Partitioning::Hash(pb_hash_expr.iter()
+                                        .map(|pb_expr| pb_expr.try_into())
+                                        .collect::<Result<Vec<_>, _>>()?,
+                                         batch_size as usize)
+                },
+                PartitionMethod::RoundRobin(batch_size)=> Partitioning::RoundRobinBatch(batch_size as usize),
+            };
+            
+            LogicalPlanBuilder::from(&input)
+                .repartition(partitioning_scheme)?.build()
+                .map_err(|e| e.into())
+        
+        }else if let Some(empty_relation) = &self.empty_relation{
+            LogicalPlanBuilder::empty(empty_relation.produce_one_row)
+                .build()
+                .map_err(|e| e.into())
+        } else if let Some(create_extern_table) = &self.create_external_table{
+            let pb_schema = (create_extern_table.schema.clone())
+                                            .ok_or(
+                                                BallistaError::General(String::from("Protobuf deserialization error, CreateExternalTableNode was missing required field schema."))
+                                            )?;
+            
+            
+            let pb_file_type: protobuf::FileType = create_extern_table.file_type.try_into()?;
+            
+            Ok(LogicalPlan::CreateExternalTable{
+                schema: pb_schema.try_into()?,
+                name: create_extern_table.name.clone(),
+                location: create_extern_table.location.clone(),
+                file_type: pb_file_type.into(),
+                has_header: create_extern_table.has_header,
+            })
+        } else if let Some(explain) = &self.explain{
+            let input: LogicalPlan = convert_box_required!(self.input)?;
+            LogicalPlanBuilder::from(&input)
+                .explain(explain.verbose)?.build()
+                .map_err(|e| e.into())
         } else if let Some(limit) = &self.limit {
             let input: LogicalPlan = convert_box_required!(self.input)?;
             LogicalPlanBuilder::from(&input)
@@ -139,6 +189,27 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
         }
     }
 }
+
+impl TryInto<datafusion::logical_plan::DFSchema> for protobuf::Schema{
+    type Error = BallistaError;
+    fn try_into(self)->Result<datafusion::logical_plan::DFSchema, Self::Error>{
+        let schema: Schema = (&self).try_into()?;
+        schema.try_into().map_err(|df_err| BallistaError::DataFusionError(df_err))
+    }
+} 
+
+impl TryInto<datafusion::logical_plan::DFSchemaRef> for protobuf::Schema{
+    type Error = BallistaError;
+    fn try_into(self) -> Result<datafusion::logical_plan::DFSchemaRef, Self::Error> {
+        use datafusion::logical_plan::ToDFSchema;
+        let schema: Schema = (&self).try_into()?;
+        schema.to_dfschema_ref().map_err(|df_err| BallistaError::DataFusionError(df_err))
+    }
+}
+
+
+
+
 
 impl TryInto<Expr> for &protobuf::LogicalExprNode {
     type Error = BallistaError;
@@ -326,6 +397,32 @@ impl TryInto<Schema> for &protobuf::Schema {
         Ok(Schema::new(fields))
     }
 }
+use std::convert::TryFrom;
+impl TryFrom<i32> for protobuf::FileType{
+    type Error = BallistaError;
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        use protobuf::FileType;
+        match value{
+            _x if _x == FileType::NdJson as i32   => Ok(FileType::NdJson),
+            _x if _x == FileType::Parquet as i32   => Ok(FileType::Parquet),
+            _x if _x == FileType::Csv as i32   => Ok(FileType::Csv),
+            invalid => Err(BallistaError::General(format!("Attempted to convert invalid i32 to protobuf::Filetype: {}",invalid )))
+        }
+    }
+}
+
+impl Into<datafusion::sql::parser::FileType> for protobuf::FileType{
+    fn into(self)->datafusion::sql::parser::FileType{
+        use datafusion::sql::parser::FileType;
+        match self{
+            protobuf::FileType::NdJson => FileType::NdJson,
+            protobuf::FileType::Parquet => FileType::Parquet,
+            protobuf::FileType::Csv => FileType::CSV,
+        }
+    }
+}
+
+
 
 // impl TryInto<PhysicalPlan> for &protobuf::PhysicalPlanNode {
 //     type Error = BallistaError;

--- a/rust/ballista/src/serde/logical_plan/from_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/from_proto.rs
@@ -114,7 +114,16 @@ impl TryInto<LogicalPlan> for &protobuf::LogicalPlanNode {
             LogicalPlanBuilder::scan_parquet(&scan.path, None, 24)? //TODO projection, concurrency
                 .build()
                 .map_err(|e| e.into())
-        } else {
+        } else if let Some(sort) = &self.sort {
+            let input: LogicalPlan = convert_box_required!(self.input)?;
+            let sort_expr: Vec<Expr> = sort.expr.iter()
+                                        .map(|expr| expr.try_into())
+                                        .collect::<Result<Vec<Expr>, _>>()?;
+            LogicalPlanBuilder::from(&input)
+                .sort(sort_expr)?
+                .build()
+                .map_err(|e| e.into())
+        }else {
             Err(proto_error(&format!(
                 "Unsupported logical plan '{:?}'",
                 self

--- a/rust/ballista/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/src/serde/logical_plan/mod.rs
@@ -14,3 +14,190 @@
 
 pub mod from_proto;
 pub mod to_proto;
+
+#[cfg(test)]
+mod roundtrip_tests {
+
+    use super::super::super::error::Result;
+    use super::super::protobuf;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::logical_plan::{LogicalPlan, LogicalPlanBuilder};
+    use datafusion::physical_plan::csv::CsvReadOptions;
+    use datafusion::prelude::*;
+    use core::panic;
+    use std::convert::TryInto;
+
+
+    //Given a identity of a LogicalPlan converts it to protobuf and back, using debug formatting to test equality.
+    macro_rules! roundtrip_test {
+        ($initial_struct:ident, $proto_type:ty, $struct_type:ty) => {
+            let proto: $proto_type = (&$initial_struct).try_into()?;
+            let round_trip: $struct_type = (&proto).try_into()?;
+            assert_eq!(format!("{:?}", $initial_struct), format!("{:?}", round_trip));
+        };
+        ($initial_struct:ident, $struct_type:ty)=>{
+            roundtrip_test!($initial_struct, protobuf::LogicalPlanNode, $struct_type);
+        };
+        ($initial_struct:ident)=>{
+            roundtrip_test!($initial_struct, protobuf::LogicalPlanNode, LogicalPlan);
+        };
+    }
+
+
+    #[test]
+    fn roundtrip_repartition()->Result<()>{
+        use datafusion::logical_plan::{Partitioning, Expr};
+        let test_batch_sizes = [usize::MIN, usize::MAX, 43256];
+        let test_expr: Vec<Expr> = vec![Expr::Column("c1".to_string()) + Expr::Column("c2".to_string()), Expr::Literal((4.0).into()) ];
+        
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ]);
+
+        let plan = std::sync::Arc::new(LogicalPlanBuilder::scan_csv(
+            "employee.csv",
+            CsvReadOptions::new().schema(&schema).has_header(true),
+            Some(vec![3, 4]),
+        ).and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.build()).unwrap());
+        
+        
+        
+        for batch_size in test_batch_sizes.iter(){
+            let rr_repartition = Partitioning::RoundRobinBatch(*batch_size);
+            let roundtrip_plan = LogicalPlan::Repartition{input: plan.clone(), partitioning_scheme: rr_repartition};
+            roundtrip_test!(roundtrip_plan);
+
+            let h_repartition = Partitioning::Hash(test_expr.clone(), *batch_size);
+            let roundtrip_plan = LogicalPlan::Repartition{input: plan.clone(), partitioning_scheme: h_repartition};
+
+            roundtrip_test!(roundtrip_plan);
+            
+            let no_expr_hrepartition = Partitioning::Hash(Vec::new(), *batch_size);
+            let roundtrip_plan = LogicalPlan::Repartition{input: plan.clone(), partitioning_scheme: no_expr_hrepartition};
+            roundtrip_test!(roundtrip_plan);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_create_external_table()->Result<()>{
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ]);
+        use datafusion::logical_plan::{ToDFSchema};
+        let df_schema_ref = schema.to_dfschema_ref()?;
+        use datafusion::sql::parser::FileType;
+        let filetypes:[FileType; 3] = [FileType::NdJson, FileType::Parquet,FileType::CSV];
+        for file in filetypes.iter(){
+            let create_table_node = LogicalPlan::CreateExternalTable{
+                schema: df_schema_ref.clone(),
+                name: String::from("TestName"),
+                location: String::from("employee.csv"),
+                file_type: file.clone(),
+                has_header: true,
+            };
+            roundtrip_test!(create_table_node);
+        }
+
+        Ok(())
+    }
+
+
+    #[test]
+    fn roundtrip_explain()->Result<()>{
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ]);
+
+        let verbose_plan = LogicalPlanBuilder::scan_csv(
+            "employee.csv",
+            CsvReadOptions::new().schema(&schema).has_header(true),
+            Some(vec![3, 4]),
+        ).and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.explain(true))
+        .and_then(|plan| plan.build()).unwrap();
+
+        let plan = LogicalPlanBuilder::scan_csv(
+            "employee.csv",
+            CsvReadOptions::new().schema(&schema).has_header(true),
+            Some(vec![3, 4]),
+        ).and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.explain(false))
+        .and_then(|plan| plan.build()).unwrap();
+
+
+        
+        roundtrip_test!(plan);
+        roundtrip_test!(verbose_plan);
+        Ok(())
+    }
+
+
+    #[test]
+    fn roundtrip_sort()->Result<()>{
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ]);
+
+        let plan = LogicalPlanBuilder::scan_csv(
+            "employee.csv",
+            CsvReadOptions::new().schema(&schema).has_header(true),
+            Some(vec![3, 4]),
+        ).and_then(|plan| plan.sort(vec![col("salary")]))
+        .and_then(|plan| plan.build()).unwrap();
+        roundtrip_test!(plan);
+        Ok(())
+    }
+
+
+    #[test]
+    fn roundtrip_empty_relation()->Result<()>{
+        let plan_false = LogicalPlanBuilder::empty(false).build().unwrap();
+        roundtrip_test!(plan_false);
+
+        let plan_true = LogicalPlanBuilder::empty(true).build().unwrap();
+        roundtrip_test!(plan_true);
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_logical_plan() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ]);
+
+        let plan = LogicalPlanBuilder::scan_csv(
+            "employee.csv",
+            CsvReadOptions::new().schema(&schema).has_header(true),
+            Some(vec![3, 4]),
+        )
+        .and_then(|plan| plan.aggregate(vec![col("state")], vec![max(col("salary"))]))
+        .and_then(|plan| plan.build())
+        .unwrap();
+
+        roundtrip_test!(plan);
+        Ok(())
+    }
+}
+

--- a/rust/ballista/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/to_proto.rs
@@ -171,11 +171,79 @@ impl TryInto<protobuf::LogicalPlanNode> for &LogicalPlan {
                     expr: selection_expr,
                 });
                 Ok(node)
-            }
-            LogicalPlan::Repartition { .. } => unimplemented!(),
-            LogicalPlan::EmptyRelation { .. } => unimplemented!(),
-            LogicalPlan::CreateExternalTable { .. } => unimplemented!(),
-            LogicalPlan::Explain { .. } => unimplemented!(),
+            },
+            LogicalPlan::Repartition { input, partitioning_scheme } => {
+                use datafusion::logical_plan::Partitioning;
+                let input: protobuf::LogicalPlanNode = input.as_ref().try_into()?;
+                let mut node = empty_logical_plan_node();
+                node.input = Some(Box::new(input));
+                
+                //Assumed common usize field was batch size
+                //Used u64 to avoid any nastyness involving large values, most data clusters are probably uniformly 64 bits any ways
+                use protobuf::repartition_node::PartitionMethod;
+
+                let pb_partition_method = match partitioning_scheme{
+                    Partitioning::Hash(exprs, batch_size)=>{
+                        PartitionMethod::Hash(protobuf::HashRepartition{
+                            hash_expr: exprs.iter()
+                            .map(|expr| expr.try_into())
+                            .collect::<Result<Vec<_>, BallistaError>>()?,
+                            batch_size: *batch_size as u64,
+                        })
+                    },
+                    Partitioning::RoundRobinBatch(batch_size)  =>{
+                        PartitionMethod::RoundRobin(*batch_size as u64)
+                    }
+                };
+
+                node.repartition = Some(protobuf::RepartitionNode{
+                    partition_method: Some(pb_partition_method),
+                });
+                
+                Ok(node)
+            },
+            LogicalPlan::EmptyRelation { produce_one_row, .. } =>{
+                let mut node = empty_logical_plan_node();                  
+                node.empty_relation = Some(protobuf::EmptyRelationNode{produce_one_row: *produce_one_row});                          
+                Ok(node)
+
+            },
+            LogicalPlan::CreateExternalTable { name, location, file_type, has_header , schema: df_schema} => {
+                let mut node = empty_logical_plan_node();
+                use datafusion::sql::parser::FileType;
+                let schema: Schema = df_schema.as_ref().clone().into();
+                let pb_schema: protobuf::Schema = (&schema).try_into()
+                                                        .map_err(
+                                                                |e| BallistaError::General(format!("Could not convert schema into protobuf: {:?}", e)
+                                                            )
+                                                        )?;
+                
+
+                let pb_file_type: protobuf::FileType = match file_type{
+                    FileType::NdJson => protobuf::FileType::NdJson,
+                    FileType::Parquet => protobuf::FileType::Parquet,
+                    FileType::CSV => protobuf::FileType::Csv,
+                };
+                
+            
+                node.create_external_table = Some(protobuf::CreateExternalTableNode{
+                    name: name.clone(),
+                    location: location.clone(),
+                    file_type: pb_file_type as i32,
+                    has_header: *has_header,
+                    schema: Some(pb_schema),
+                });
+                Ok(node)
+            },
+            LogicalPlan::Explain { verbose, plan, ..} => {
+                let mut node = empty_logical_plan_node();
+                let input: protobuf::LogicalPlanNode = plan.as_ref().try_into()?;
+                node.input = Some(Box::new(input));
+                node.explain = Some(protobuf::ExplainNode{
+                    verbose: *verbose,  
+                });    
+                Ok(node)
+            },
             LogicalPlan::Extension { .. } => unimplemented!(),
             // _ => Err(BallistaError::General(format!(
             //     "logical plan to_proto {:?}",


### PR DESCRIPTION
Implemented serde for the LogicalPlan nodes repartition, create external table, empty relation, and explain. I'm a little unsure about the create external table implementation because as far as I could tell none of the other node types  serialize their schema and I couldn't find a way around serializing it for this node.  

Some smaller changes made:

1.  Changed [build.rs](rust/ballista/build.rs) so it is only run when [ballista.proto](rust/ballista/proto/ballista.proto) is changed. I also changed from a panic to returning a result as I was finding the stack traces were  noise when changing the protobuf definition.

2.  Moved logical plan roundtrip tests to [src/serde/logical_plan/mod.rs](rust/ballista/src/serde/logical_plan/mod.rs).