### PR TITLE
Add protobuf installation in rust env guide

### DIFF
--- a/docs/dev-env-rust.md
+++ b/docs/dev-env-rust.md
@@ -10,7 +10,23 @@ sudo apt-get install pkg-config libssl-dev
 ```
 
 
+## Install Protobuf
 
+Use following instructions to install the protobuf compiler on Ubuntu or similar Linux platforms.
 
+```
+$ wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protobuf-all-3.11.4.tar.gz
+$ tar xzf protobuf-all-3.11.4.tar.gz
+$ cd protobuf-3.11.4
+$ ./configure
+$ make
+$ sudo make install
+$ sudo ldconfig
+```
 
+MacOS user can install with `brew`
+
+```
+$ brew install protobuf
+```
 


### PR DESCRIPTION
Hello,
I'm setting up the dev environment by following the guide, and found protobuf installation was missing.

Please check~