### PR TITLE
Added rust code formatting check to CI. Closes #364 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,7 @@
 name: Rust
-# Runs rust ci only when files in rust directory have been changed
-on: 
-  push:
-    paths: 
-      - 'rust/**'
-  pull_request:
-    paths:
-      - 'rust/**'
+
+on: [push, pull_request]
+
 # Note, toolchain version must match the rustup version: either "nightly" or "nightly-YYYY-MM-DD"
 # and must contain the toolchain for the OS at the end.
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   #TOOLCHAIN_VERSION: stable-x86_64-pc-windows-msvc
 
 jobs:
-  Pre-Test Checks:
+  PreTestChecks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
 
   Ubuntu:
     runs-on: ubuntu-latest
-    needs: [Pre-Test Checks]
+    needs: [PreTestChecks]
     steps:
     - uses: actions/checkout@v2
     - name: Build Ballista
@@ -31,7 +31,7 @@ jobs:
 
   Mac:
     runs-on: macOS-latest
-    needs: [Pre-Test Checks]
+    needs: [PreTestChecks]
     steps:
     - uses: actions/checkout@v2
     - name: Build Ballista
@@ -41,7 +41,7 @@ jobs:
 
   Windows:
     runs-on: windows-2016
-    needs: [Pre-Test Checks]
+    needs: [PreTestChecks]
     steps:
     - uses: actions/checkout@v2
     - name: Prepare the Windows Build Environment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,12 @@
 name: Rust
-
-on: [push,pull_request]
-
+# Runs rust ci only when files in rust directory have been changed
+on: 
+  push:
+    paths: 
+      - 'rust/**'
+  pull_request:
+    paths:
+      - 'rust/**'
 # Note, toolchain version must match the rustup version: either "nightly" or "nightly-YYYY-MM-DD"
 # and must contain the toolchain for the OS at the end.
 
@@ -10,15 +15,18 @@ env:
   #TOOLCHAIN_VERSION: stable-x86_64-pc-windows-msvc
 
 jobs:
-  Lint:
+  Pre-Test Checks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Lint Ballista
       run: cd rust && cargo clippy -- -D warnings
+    - name: Check Ballista formatting
+      run: cd rust && cargo fmt -- --check
 
   Ubuntu:
     runs-on: ubuntu-latest
+    needs: [Pre-Test Checks]
     steps:
     - uses: actions/checkout@v2
     - name: Build Ballista
@@ -28,6 +36,7 @@ jobs:
 
   Mac:
     runs-on: macOS-latest
+    needs: [Pre-Test Checks]
     steps:
     - uses: actions/checkout@v2
     - name: Build Ballista
@@ -37,6 +46,7 @@ jobs:
 
   Windows:
     runs-on: windows-2016
+    needs: [Pre-Test Checks]
     steps:
     - uses: actions/checkout@v2
     - name: Prepare the Windows Build Environment


### PR DESCRIPTION
Added a rust code formatting check to CI. 
Added job dependency so that tests run only after lints and formatting checks pass. I wasn't sure what the Docker job does so i didn't change it.
Added rule to only run rust CI when a file in rust/ is changed.

It might be worth it to check a rustfmt.toml file into the repo just to make sure that there aren't any formatting inconsistencies between contributor configurations.