### PR TITLE
Exploratory work on ShuffleHashJoinExec / ShuffleWriteExec

### DIFF
--- a/rust/ballista/src/lib.rs
+++ b/rust/ballista/src/lib.rs
@@ -26,6 +26,7 @@ pub mod flight_service;
 pub mod k8s;
 pub mod memory_stream;
 pub mod prelude;
+pub mod shuffle_hash_join;
 pub mod shuffle_write;
 pub mod utils;
 

--- a/rust/ballista/src/shuffle_hash_join.rs
+++ b/rust/ballista/src/shuffle_hash_join.rs
@@ -1,0 +1,137 @@
+// Copyright 2021 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The ShuffleHashJoinExec operator accepts two inputs that are hash-partitioned on join keys so
+//! that each partition of the Shuffle Hash Join operates on the corresponding partitions of the
+//! two inputs
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_plan::{ExecutionPlan, Partitioning, SendableRecordBatchStream};
+
+#[derive(Debug, Clone)]
+pub struct ShuffleHashJoinExec {
+    left: Arc<dyn ExecutionPlan>,
+    right: Arc<dyn ExecutionPlan>,
+}
+
+impl ShuffleHashJoinExec {
+    /// Create a new ShuffleHashJoinExec and validate that both inputs are using hash partitioning
+    /// with compatible expressions
+    pub fn try_new(left: Arc<dyn ExecutionPlan>, right: Arc<dyn ExecutionPlan>) -> Result<Self> {
+        match (left.output_partitioning(), right.output_partitioning()) {
+            (Partitioning::Hash(left_expr, left_n), Partitioning::Hash(right_expr, right_n)) => {
+                if left_n == 0 {
+                    Err(DataFusionError::Plan(
+                        "Both inputs to ShuffleHashJoinExec must have at least one hash expression"
+                            .to_owned(),
+                    ))
+                } else if left_n != right_n {
+                    Err(DataFusionError::Plan(
+                        "Both inputs to ShuffleHashJoinExec must have same number of partitions"
+                            .to_owned(),
+                    ))
+                } else {
+                    let left_types = left_expr
+                        .iter()
+                        .map(|e| e.data_type(left.schema().as_ref()))
+                        .collect::<Result<Vec<_>>>()?;
+                    let right_types = right_expr
+                        .iter()
+                        .map(|e| e.data_type(right.schema().as_ref()))
+                        .collect::<Result<Vec<_>>>()?;
+                    if left_types == right_types {
+                        Ok(Self { left, right })
+                    } else {
+                        Err(DataFusionError::Plan(
+                            "Both inputs to ShuffleHashJoinExec must be partitioned with \
+                            compatible hash expressions"
+                                .to_owned(),
+                        ))
+                    }
+                }
+            }
+            _ => Err(DataFusionError::Plan(
+                "Both inputs to ShuffleHashJoinExec must have hash partitioning".to_owned(),
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for ShuffleHashJoinExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        todo!()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.right.output_partitioning()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.left.clone(), self.right.clone()]
+    }
+
+    fn with_new_children(
+        &self,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        todo!()
+    }
+
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        let _left = self.left.execute(partition).await?;
+        let _right = self.right.execute(partition).await?;
+
+        //TODO delegate to DataFusion HashJoinExec logic
+
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::physical_plan::memory::MemoryExec;
+
+    #[test]
+    fn input_not_hash_partitioned() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, false)]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+
+        let partitions = vec![vec![batch.clone()], vec![batch]];
+        let mem_table: Arc<dyn ExecutionPlan> =
+            Arc::new(MemoryExec::try_new(&partitions, schema, None)?);
+
+        let result = ShuffleHashJoinExec::try_new(mem_table.clone(), mem_table.clone());
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}

--- a/rust/ballista/src/shuffle_hash_join.rs
+++ b/rust/ballista/src/shuffle_hash_join.rs
@@ -15,6 +15,8 @@
 //! The ShuffleHashJoinExec operator accepts two inputs that are hash-partitioned on join keys so
 //! that each partition of the Shuffle Hash Join operates on the corresponding partitions of the
 //! two inputs
+//!
+//! This operator is EXPERIMENTAL and still under development
 
 use std::any::Any;
 use std::sync::Arc;

--- a/rust/ballista/src/shuffle_write.rs
+++ b/rust/ballista/src/shuffle_write.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The ShuffleWriteExec operator simply executes a physical plan and streams each output partition
-//! to disk so that the Shuffle Read operator can later request to stream this data in subsequent
-//! stages of query execution.
+//! The ShuffleWriteExec operator simply executes one partition of a physical plan, optionally
+//! repartitions the output, and streams each output partition to disk for later retrieval by
+//! future query stages.
 //!
 //! This operator is EXPERIMENTAL and still under development
 
@@ -36,16 +36,27 @@ use tonic::codegen::Arc;
 pub struct ShuffleWriteExec {
     /// The child plan to execute and write shuffle partitions for
     child: Arc<dyn ExecutionPlan>,
+    /// Partition to execute
+    child_partition: usize,
     /// Output path for shuffle partitions
     output_path: String,
+    /// Number of shuffle partitions to crate
+    target_partition_count: usize,
 }
 
 impl ShuffleWriteExec {
     /// Create a new ShuffleWriteExec
-    pub fn new(child: Arc<dyn ExecutionPlan>, output_path: &str) -> Self {
+    pub fn new(
+        child: Arc<dyn ExecutionPlan>,
+        child_partition: usize,
+        output_path: &str,
+        target_partition_count: usize,
+    ) -> Self {
         Self {
             child,
+            child_partition,
             output_path: output_path.to_owned(),
+            target_partition_count,
         }
     }
 }
@@ -87,19 +98,23 @@ impl ExecutionPlan for ShuffleWriteExec {
         let mut partition_location =
             StringBuilder::with_capacity(num_partitions, num_partitions * 256);
 
-        // TODO use tokio to execute all input partitions in parallel
+        // execute input partition
+        let mut stream = self.child.execute(self.child_partition).await?;
 
-        for input_partition in 0..num_partitions {
-            // execute input partition
-            let mut stream = self.child.execute(input_partition).await?;
+        //TODO apply partitioning - for now we just write out a single shuffle partition (which
+        // is just the raw output from the executed plan's partition)
+        //
+        // When performing a shuffle as an input to a ShuffleHashJoin we will want to use hash
+        // partitioning. In other cases we can just repartition using round-robin with the goal
+        // of increasing parallelism in future query stages
 
-            // stream data to disk in IPC format
-            let path = format!("{}/{}", self.output_path, input_partition);
-            write_stream_to_disk(&mut stream, &path).await?;
+        // stream data to disk in IPC format
+        let shuffle_partition = 0;
+        let path = format!("{}/{}", self.output_path, shuffle_partition);
+        write_stream_to_disk(&mut stream, &path).await?;
 
-            partition_id.append_value(input_partition as u32)?;
-            partition_location.append_value(&path)?;
-        }
+        partition_id.append_value(shuffle_partition as u32)?;
+        partition_location.append_value(&path)?;
 
         let partition_id: ArrayRef = Arc::new(partition_id.finish());
         let partition_location: ArrayRef = Arc::new(partition_location.finish());
@@ -137,7 +152,8 @@ mod tests {
 
         let tmp_dir = TempDir::new()?;
 
-        let shuffle_write_exec = ShuffleWriteExec::new(mem_table, tmp_dir.path().to_str().unwrap());
+        let shuffle_write_exec =
+            ShuffleWriteExec::new(mem_table, 0, tmp_dir.path().to_str().unwrap(), 200);
         assert_eq!(
             1,
             shuffle_write_exec.output_partitioning().partition_count()
@@ -146,7 +162,7 @@ mod tests {
         let mut stream = shuffle_write_exec.execute(0).await?;
         let batch = stream.next().await.unwrap()?;
         assert_eq!(2, batch.num_columns());
-        assert_eq!(2, batch.num_rows());
+        assert_eq!(1, batch.num_rows());
         assert!(stream.next().await.is_none());
 
         Ok(())

--- a/rust/ballista/src/shuffle_write.rs
+++ b/rust/ballista/src/shuffle_write.rs
@@ -15,6 +15,8 @@
 //! The ShuffleWriteExec operator simply executes a physical plan and streams each output partition
 //! to disk so that the Shuffle Read operator can later request to stream this data in subsequent
 //! stages of query execution.
+//!
+//! This operator is EXPERIMENTAL and still under development
 
 use std::any::Any;
 


### PR DESCRIPTION
This PR starts to implement some experimental code for ShuffleHashJoinExec / ShuffleWriteExec in preparation for supporting distributed query execution. 