### PR TITLE
Implement serdes for LogicalExprNode: Between, Case, Cast, Sort

### DIFF
--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -44,6 +44,11 @@ message LogicalExprNode {
     IsNull is_null_expr = 60;
     IsNotNull is_not_null_expr = 61;
     Not not_expr = 62;
+
+    BetweenNode between = 70;
+    CaseNode case_ = 71;
+    CastNode cast = 72;
+    SortExprNode sort = 73;
   }
 }
 
@@ -82,6 +87,35 @@ enum AggregateFunction {
 message AggregateExprNode {
   AggregateFunction aggr_function = 1;
   LogicalExprNode expr = 2;
+}
+
+message BetweenNode {
+  LogicalExprNode expr = 1;
+  bool negated = 2;
+  LogicalExprNode low = 3;
+  LogicalExprNode high = 4;
+}
+
+message CaseNode {
+  LogicalExprNode expr = 1;
+  repeated WhenThen when_then_expr = 2;
+  LogicalExprNode else_expr = 3;
+}
+
+message WhenThen {
+  LogicalExprNode when_expr = 1;
+  LogicalExprNode then_expr = 2;
+}
+
+message CastNode {
+  LogicalExprNode expr = 1;
+  ArrowType arrow_type = 2;
+}
+
+message SortExprNode {
+  LogicalExprNode expr = 1;
+  bool asc = 2;
+  bool nulls_first = 3;
 }
 
 // LogicalPlan is a nested type

--- a/rust/ballista/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/src/serde/logical_plan/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 Andy Grove
 //
-// expr: (), negated: (), low: (), high: () expr: (), negated: (), low: (), high: () Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/rust/ballista/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/src/serde/logical_plan/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 Andy Grove
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// expr: (), negated: (), low: (), high: () expr: (), negated: (), low: (), high: () Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -22,7 +22,7 @@ mod roundtrip_tests {
     use super::super::protobuf;
     use arrow::datatypes::{DataType, Field, Schema};
     use core::panic;
-    use datafusion::logical_plan::{LogicalPlan, LogicalPlanBuilder};
+    use datafusion::logical_plan::{Expr, LogicalPlan, LogicalPlanBuilder};
     use datafusion::physical_plan::csv::CsvReadOptions;
     use datafusion::prelude::*;
     use std::convert::TryInto;
@@ -47,7 +47,7 @@ mod roundtrip_tests {
 
     #[test]
     fn roundtrip_repartition() -> Result<()> {
-        use datafusion::logical_plan::{Expr, Partitioning};
+        use datafusion::logical_plan::Partitioning;
         let test_batch_sizes = [usize::MIN, usize::MAX, 43256];
         let test_expr: Vec<Expr> = vec![
             Expr::Column("c1".to_string()) + Expr::Column("c2".to_string()),
@@ -213,6 +213,50 @@ mod roundtrip_tests {
         .unwrap();
 
         roundtrip_test!(plan);
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_between() -> Result<()> {
+        let test_expr = Expr::Between {
+            expr: Box::new(Expr::Literal((1.0).into())),
+            negated: true,
+            low: Box::new(Expr::Literal((2.0).into())),
+            high: Box::new(Expr::Literal((3.0).into())),
+        };
+        roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_case() -> Result<()> {
+        let test_expr = Expr::Case {
+            expr: Some(Box::new(Expr::Literal((1.0).into()))),
+            when_then_expr: vec![(Box::new(Expr::Literal((2.0).into())), Box::new(Expr::Literal((3.0).into())))],
+            else_expr: Some(Box::new(Expr::Literal((4.0).into()))),
+        };
+        roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_cast() -> Result<()> {
+        let test_expr = Expr::Cast {
+            expr: Box::new(Expr::Literal((1.0).into())),
+            data_type: DataType::Boolean,
+        };
+        roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_sort_expr() -> Result<()> {
+        let test_expr = Expr::Sort {
+            expr: Box::new(Expr::Literal((1.0).into())),
+            asc: true,
+            nulls_first: true,
+        };
+        roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
         Ok(())
     }
 }

--- a/rust/ballista/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/src/serde/logical_plan/mod.rs
@@ -232,7 +232,10 @@ mod roundtrip_tests {
     fn roundtrip_case() -> Result<()> {
         let test_expr = Expr::Case {
             expr: Some(Box::new(Expr::Literal((1.0).into()))),
-            when_then_expr: vec![(Box::new(Expr::Literal((2.0).into())), Box::new(Expr::Literal((3.0).into())))],
+            when_then_expr: vec![(
+                Box::new(Expr::Literal((2.0).into())),
+                Box::new(Expr::Literal((3.0).into())),
+            )],
             else_expr: Some(Box::new(Expr::Literal((4.0).into()))),
         };
         roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);

--- a/rust/ballista/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/to_proto.rs
@@ -454,7 +454,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                 else_expr,
             } => {
                 let when_then_expr = when_then_expr
-                    .into_iter()
+                    .iter()
                     .map(|(w, t)| {
                         Ok(protobuf::WhenThen {
                             when_expr: Some(w.as_ref().try_into()?),

--- a/rust/ballista/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/to_proto.rs
@@ -432,11 +432,75 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                     expr_type: Some(protobuf::logical_expr_node::ExprType::IsNotNullExpr(expr)),
                 })
             }
-            Expr::Between { .. } => unimplemented!(),
+            Expr::Between {
+                expr,
+                negated,
+                low,
+                high,
+            } => {
+                let expr = Box::new(protobuf::BetweenNode {
+                    expr: Some(Box::new(expr.as_ref().try_into()?)),
+                    negated: *negated,
+                    low: Some(Box::new(low.as_ref().try_into()?)),
+                    high: Some(Box::new(high.as_ref().try_into()?)),
+                });
+                Ok(protobuf::LogicalExprNode {
+                    expr_type: Some(protobuf::logical_expr_node::ExprType::Between(expr)),
+                })
+            }
+            Expr::Case {
+                expr,
+                when_then_expr,
+                else_expr,
+            } => {
+                let when_then_expr = when_then_expr
+                    .into_iter()
+                    .map(|(w, t)| {
+                        Ok(protobuf::WhenThen {
+                            when_expr: Some(w.as_ref().try_into()?),
+                            then_expr: Some(t.as_ref().try_into()?),
+                        })
+                    })
+                    .collect::<Result<Vec<protobuf::WhenThen>, BallistaError>>()?;
+                let expr = Box::new(protobuf::CaseNode {
+                    expr: match expr {
+                        Some(e) => Some(Box::new(e.as_ref().try_into()?)),
+                        None => None,
+                    },
+                    when_then_expr,
+                    else_expr: match else_expr {
+                        Some(e) => Some(Box::new(e.as_ref().try_into()?)),
+                        None => None,
+                    },
+                });
+                Ok(protobuf::LogicalExprNode {
+                    expr_type: Some(protobuf::logical_expr_node::ExprType::Case(expr)),
+                })
+            }
+            Expr::Cast { expr, data_type } => {
+                let expr = Box::new(protobuf::CastNode {
+                    expr: Some(Box::new(expr.as_ref().try_into()?)),
+                    arrow_type: to_proto_arrow_type(data_type)?.into(),
+                });
+                Ok(protobuf::LogicalExprNode {
+                    expr_type: Some(protobuf::logical_expr_node::ExprType::Cast(expr)),
+                })
+            }
+            Expr::Sort {
+                expr,
+                asc,
+                nulls_first,
+            } => {
+                let expr = Box::new(protobuf::SortExprNode {
+                    expr: Some(Box::new(expr.as_ref().try_into()?)),
+                    asc: *asc,
+                    nulls_first: *nulls_first,
+                });
+                Ok(protobuf::LogicalExprNode {
+                    expr_type: Some(protobuf::logical_expr_node::ExprType::Sort(expr)),
+                })
+            }
             Expr::Negative(_) => unimplemented!(),
-            Expr::Case { .. } => unimplemented!(),
-            Expr::Cast { .. } => unimplemented!(),
-            Expr::Sort { .. } => unimplemented!(),
             Expr::InList { .. } => unimplemented!(),
             Expr::Wildcard => unimplemented!(),
             // _ => Err(BallistaError::General(format!(
@@ -471,6 +535,7 @@ impl TryInto<protobuf::Schema> for &Schema {
 
 fn to_proto_arrow_type(dt: &DataType) -> Result<protobuf::ArrowType, BallistaError> {
     match dt {
+        DataType::Boolean => Ok(protobuf::ArrowType::Bool),
         DataType::Int8 => Ok(protobuf::ArrowType::Int8),
         DataType::Int16 => Ok(protobuf::ArrowType::Int16),
         DataType::Int32 => Ok(protobuf::ArrowType::Int32),
@@ -479,9 +544,11 @@ fn to_proto_arrow_type(dt: &DataType) -> Result<protobuf::ArrowType, BallistaErr
         DataType::UInt16 => Ok(protobuf::ArrowType::Uint16),
         DataType::UInt32 => Ok(protobuf::ArrowType::Uint32),
         DataType::UInt64 => Ok(protobuf::ArrowType::Uint64),
+        DataType::Float16 => Ok(protobuf::ArrowType::HalfFloat),
         DataType::Float32 => Ok(protobuf::ArrowType::Float),
         DataType::Float64 => Ok(protobuf::ArrowType::Double),
         DataType::Utf8 => Ok(protobuf::ArrowType::Utf8),
+        DataType::Binary => Ok(protobuf::ArrowType::Binary),
         other => Err(BallistaError::General(format!(
             "logical_plan::to_proto() Unsupported data type {:?}",
             other


### PR DESCRIPTION
I wasn't sure how to deal with the `DataType` <> `ArrowType` conversion for the `Cast` operator, since it looks like
(per https://github.com/apache/arrow/blob/master/rust/arrow/src/compute/kernels/cast.rs#L51) there are many
types of casts that are possible that weren't representable with the currently serializable types. I didn't want to change the
proto `ArrowType` in this PR, so I only added types to `from_proto_arrow_type`/`to_proto_arrow_type` that didn't have size
params.

Fixes #369, #370, #371, #372