### PR TITLE
Use async sleep to avoid blocking thread

### DIFF
--- a/rust/ballista/src/etcd.rs
+++ b/rust/ballista/src/etcd.rs
@@ -14,7 +14,6 @@
 
 //! Support for etcd discovery mechanism.
 
-use std::thread;
 use std::time::Duration;
 
 use crate::error::{ballista_error, Result};
@@ -63,7 +62,7 @@ async fn main_loop(etcd_urls: &str, cluster_name: &str, uuid: &Uuid, host: &str,
             }
             Err(e) => warn!("Failed to connect to etcd {:?}", e.to_string()),
         }
-        thread::sleep(Duration::from_secs(15));
+        tokio::time::delay_for(Duration::from_secs(15)).await;
     }
 }
 


### PR DESCRIPTION
Since this method is called through `tokio::spawn`, using `thread::sleep` isn't a great idea since it will completely block one of tokio's threads in its threadpool. By using tokio's version of sleep (called delay_for in tokio 0.2 but called sleep in tokio 1.0), the thread can handle other tasks while the etcd loop is idle.