### PR TITLE
WIP: Implement more functionality in the distributed query planner

### DIFF
--- a/rust/ballista/examples/planner.rs
+++ b/rust/ballista/examples/planner.rs
@@ -1,0 +1,174 @@
+// Copyright 2020 Andy Grove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use ballista::prelude::*;
+use ballista::scheduler::planner::DistributedPlanner;
+use ballista::serde::scheduler::ExecutorMeta;
+use datafusion::execution::context::ExecutionContext;
+use datafusion::physical_plan::csv::CsvReadOptions;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // assumes benchmark data is available
+    let tpch_data = "/home/andy/git/ballista/benchmarks/tpch/data";
+
+    let ctx = BallistaContext::remote("localhost", 50051, HashMap::new());
+
+    let tables = vec!["lineitem", "orders"];
+    for table in &tables {
+        let schema = get_schema(table);
+        let options = CsvReadOptions::new()
+            .schema(&schema)
+            .file_extension(".tbl")
+            .has_header(false)
+            .delimiter(b'|');
+        let filename = format!("{}/{}.tbl", tpch_data, table);
+        println!("Registering table {} using path {}", table, filename);
+        ctx.register_csv(table, &filename, options)?;
+    }
+
+    let plan = ctx.sql(
+        "select
+    l_shipmode,o_orderpriority
+from
+    lineitem
+        join
+    orders
+    on
+            l_orderkey = o_orderkey
+",
+    )?;
+
+    /*
+          where
+          l_shipmode in ('MAIL', 'SHIP')
+    and l_commitdate < l_receiptdate
+    and l_shipdate < l_commitdate
+    and l_receiptdate >= date '1994-01-01'
+    and l_receiptdate < date '1995-01-01'
+
+           */
+    let df = ExecutionContext::new();
+    let plan = df.optimize(&plan.to_logical_plan())?;
+    let plan = df.create_physical_plan(&plan)?;
+
+    let executors = vec![ExecutorMeta {
+        id: "TBD".to_string(),
+        host: "localhost".to_string(),
+        port: 50051,
+    }];
+
+    let mut planner = DistributedPlanner::new(Box::new(executors));
+    planner.execute_distributed_query(plan).await?;
+
+    Ok(())
+}
+
+fn get_schema(table: &str) -> Schema {
+    // note that the schema intentionally uses signed integers so that any generated Parquet
+    // files can also be used to benchmark tools that only support signed integers, such as
+    // Apache Spark
+
+    match table {
+        "part" => Schema::new(vec![
+            Field::new("p_partkey", DataType::Int32, false),
+            Field::new("p_name", DataType::Utf8, false),
+            Field::new("p_mfgr", DataType::Utf8, false),
+            Field::new("p_brand", DataType::Utf8, false),
+            Field::new("p_type", DataType::Utf8, false),
+            Field::new("p_size", DataType::Int32, false),
+            Field::new("p_container", DataType::Utf8, false),
+            Field::new("p_retailprice", DataType::Float64, false),
+            Field::new("p_comment", DataType::Utf8, false),
+        ]),
+
+        "supplier" => Schema::new(vec![
+            Field::new("s_suppkey", DataType::Int32, false),
+            Field::new("s_name", DataType::Utf8, false),
+            Field::new("s_address", DataType::Utf8, false),
+            Field::new("s_nationkey", DataType::Int32, false),
+            Field::new("s_phone", DataType::Utf8, false),
+            Field::new("s_acctbal", DataType::Float64, false),
+            Field::new("s_comment", DataType::Utf8, false),
+        ]),
+
+        "partsupp" => Schema::new(vec![
+            Field::new("ps_partkey", DataType::Int32, false),
+            Field::new("ps_suppkey", DataType::Int32, false),
+            Field::new("ps_availqty", DataType::Int32, false),
+            Field::new("ps_supplycost", DataType::Float64, false),
+            Field::new("ps_comment", DataType::Utf8, false),
+        ]),
+
+        "customer" => Schema::new(vec![
+            Field::new("c_custkey", DataType::Int32, false),
+            Field::new("c_name", DataType::Utf8, false),
+            Field::new("c_address", DataType::Utf8, false),
+            Field::new("c_nationkey", DataType::Int32, false),
+            Field::new("c_phone", DataType::Utf8, false),
+            Field::new("c_acctbal", DataType::Float64, false),
+            Field::new("c_mktsegment", DataType::Utf8, false),
+            Field::new("c_comment", DataType::Utf8, false),
+        ]),
+
+        "orders" => Schema::new(vec![
+            Field::new("o_orderkey", DataType::Int32, false),
+            Field::new("o_custkey", DataType::Int32, false),
+            Field::new("o_orderstatus", DataType::Utf8, false),
+            Field::new("o_totalprice", DataType::Float64, false),
+            Field::new("o_orderdate", DataType::Date32, false),
+            Field::new("o_orderpriority", DataType::Utf8, false),
+            Field::new("o_clerk", DataType::Utf8, false),
+            Field::new("o_shippriority", DataType::Int32, false),
+            Field::new("o_comment", DataType::Utf8, false),
+        ]),
+
+        "lineitem" => Schema::new(vec![
+            Field::new("l_orderkey", DataType::Int32, false),
+            Field::new("l_partkey", DataType::Int32, false),
+            Field::new("l_suppkey", DataType::Int32, false),
+            Field::new("l_linenumber", DataType::Int32, false),
+            Field::new("l_quantity", DataType::Float64, false),
+            Field::new("l_extendedprice", DataType::Float64, false),
+            Field::new("l_discount", DataType::Float64, false),
+            Field::new("l_tax", DataType::Float64, false),
+            Field::new("l_returnflag", DataType::Utf8, false),
+            Field::new("l_linestatus", DataType::Utf8, false),
+            Field::new("l_shipdate", DataType::Date32, false),
+            Field::new("l_commitdate", DataType::Date32, false),
+            Field::new("l_receiptdate", DataType::Date32, false),
+            Field::new("l_shipinstruct", DataType::Utf8, false),
+            Field::new("l_shipmode", DataType::Utf8, false),
+            Field::new("l_comment", DataType::Utf8, false),
+        ]),
+
+        "nation" => Schema::new(vec![
+            Field::new("n_nationkey", DataType::Int32, false),
+            Field::new("n_name", DataType::Utf8, false),
+            Field::new("n_regionkey", DataType::Int32, false),
+            Field::new("n_comment", DataType::Utf8, false),
+        ]),
+
+        "region" => Schema::new(vec![
+            Field::new("r_regionkey", DataType::Int32, false),
+            Field::new("r_name", DataType::Utf8, false),
+            Field::new("r_comment", DataType::Utf8, false),
+        ]),
+
+        _ => unimplemented!(),
+    }
+}

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -96,7 +96,6 @@ impl FlightService for BallistaFlightService {
             }
             BallistaAction::ExecutePartition(partition) => {
                 debug!("ExecutePartition {:?}", partition);
-
                 pretty_print(partition.plan.clone(), 0);
 
                 let mut path = PathBuf::from(&self.executor.config.work_dir);

--- a/rust/ballista/src/scheduler/planner.rs
+++ b/rust/ballista/src/scheduler/planner.rs
@@ -24,6 +24,7 @@ use crate::client::BallistaClient;
 use crate::context::DFTableAdapter;
 use crate::error::Result;
 use crate::executor::query_stage::QueryStageExec;
+use crate::executor::shuffle_reader::ShuffleReaderExec;
 use crate::serde::scheduler::ExecutorMeta;
 use crate::serde::scheduler::PartitionId;
 
@@ -73,16 +74,21 @@ impl DistributedPlanner {
         execution_plan: Arc<dyn ExecutionPlan>,
     ) -> Result<()> {
         let job_uuid = Uuid::new_v4();
-        pretty_print(execution_plan.clone(), 0);
 
         let execution_plan = self.prepare_query_stages(&job_uuid, execution_plan)?;
+
+        // wrap final operator in query stage
+        let execution_plan =
+            create_query_stage(&job_uuid, self.next_stage_id(), execution_plan.clone())?;
         pretty_print(execution_plan.clone(), 0);
 
         let executors = self.scheduler_client.get_executors()?;
 
         execute(execution_plan.clone(), executors.clone())
-            .await
+            .await?
             .await?;
+
+        debug!("execute_distributed_query completed");
 
         Ok(())
     }
@@ -162,18 +168,22 @@ impl DistributedPlanner {
 async fn execute(
     plan: Arc<dyn ExecutionPlan>,
     executors: Vec<ExecutorMeta>,
-) -> Pin<Box<dyn Future<Output = Result<Vec<PartitionLocation>>>>> {
+) -> Result<Pin<Box<dyn Future<Output = Result<Arc<dyn ExecutionPlan>>>>>> {
+    debug!("execute() {}", &format!("{:?}", plan)[0..60]);
     let executors = executors.to_vec();
-    Box::pin(async move {
-        let mut partition_locations = vec![];
+    Ok(Box::pin(async move {
+        // execute children first
+        let mut children: Vec<Arc<dyn ExecutionPlan>> = vec![];
         for child in plan.children() {
-            let xx: Result<Vec<PartitionLocation>> =
-                execute(child.clone(), executors.clone()).await.await;
-            let mut part_loc = xx.unwrap();
-            partition_locations.append(&mut part_loc);
+            let executed_child = execute(child.clone(), executors.clone()).await?.await?;
+            children.push(executed_child);
         }
-        if let Some(stage) = plan.as_any().downcast_ref::<QueryStageExec>() {
-            let mut part_loc = execute_query_stage(
+        let plan = plan.with_new_children(children)?;
+
+        let new_plan: Arc<dyn ExecutionPlan> = if let Some(stage) =
+            plan.as_any().downcast_ref::<QueryStageExec>()
+        {
+            let partition_locations = execute_query_stage(
                 &stage.job_uuid,
                 stage.stage_id,
                 stage.children()[0].clone(),
@@ -181,14 +191,26 @@ async fn execute(
             )
             .await
             .unwrap();
-            partition_locations.append(&mut part_loc);
-        }
 
-        println!("execute {:?}\n\treturning {:?}", plan, partition_locations);
+            // replace the query stage with a ShuffleReaderExec that can read the partitions
+            // produced by the executed query stage
+            let shuffle_reader = ShuffleReaderExec::try_new(partition_locations, stage.schema())?;
+            Arc::new(shuffle_reader)
+        } else {
+            plan
+        };
 
-        Ok(partition_locations)
-    })
+        debug!("execute is returning:");
+        pretty_print(new_plan.clone(), 0);
+
+        Ok(new_plan)
+    }))
 }
+
+// struct Foo {
+//     plan: Arc<dyn ExecutionPlan>,
+//     partition_locations: Vec<PartitionLocation>
+// }
 
 fn create_query_stage(
     job_uuid: &Uuid,
@@ -209,32 +231,35 @@ async fn execute_query_stage(
     plan: Arc<dyn ExecutionPlan>,
     executors: Vec<ExecutorMeta>,
 ) -> Result<Vec<PartitionLocation>> {
+    debug!("execute_query_stage() stage_id={}", stage_id);
+    pretty_print(plan.clone(), 0);
+
     let partition_count = plan.output_partitioning().partition_count();
     let mut meta = Vec::with_capacity(partition_count);
 
     // TODO make this concurrent by executing all partitions at once instead of one at a time
 
     for child_partition in 0..partition_count {
-        let executor_meta = &executors[executors.len() % child_partition];
+        let executor_meta = &executors[child_partition % executors.len()];
         let mut client = BallistaClient::try_new(&executor_meta.host, executor_meta.port as usize)
             .await
             .map_err(|e| DataFusionError::Execution(format!("Ballista Error: {:?}", e)))?;
 
-        let partition_metadata = client
+        let _partition_metadata = client
             .execute_partition(*job_uuid, stage_id, child_partition, plan.clone())
             .await
             .map_err(|e| DataFusionError::Execution(format!("Ballista Error: {:?}", e)))?;
-
-        debug!(
-            "Partition {} metadata: {:?}",
-            child_partition, partition_metadata
-        );
 
         meta.push(PartitionLocation {
             partition_id: PartitionId::new(*job_uuid, stage_id, child_partition),
             executor_meta: executor_meta.clone(),
         });
     }
+
+    debug!(
+        "execute_query_stage() stage_id={} produced {:?}",
+        stage_id, meta
+    );
 
     Ok(meta)
 }
@@ -243,183 +268,9 @@ pub fn pretty_print(plan: Arc<dyn ExecutionPlan>, indent: usize) {
     for _ in 0..indent {
         print!("  ");
     }
-    println!("{:?}", plan);
+    let operator_str = format!("{:?}", plan);
+    println!("{}", &operator_str[0..60]);
     plan.children()
         .iter()
         .for_each(|c| pretty_print(c.clone(), indent + 1));
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::context::BallistaContext;
-//     use arrow::datatypes::{DataType, Field, Schema};
-//     use datafusion::execution::context::ExecutionContext;
-//     use datafusion::physical_plan::csv::CsvReadOptions;
-//     use std::collections::HashMap;
-//
-//     #[tokio::test]
-//     async fn test() -> Result<()> {
-//         // assumes benchmark data is available
-//         let tpch_data = "../../benchmarks/tpch/data";
-//
-//         let ctx = BallistaContext::remote("localhost", 50051, HashMap::new());
-//
-//         let tables = vec!["lineitem", "orders"];
-//         for table in &tables {
-//             let schema = get_schema(table);
-//             let options = CsvReadOptions::new()
-//                 .schema(&schema)
-//                 .file_extension(".tbl")
-//                 .has_header(false)
-//                 .delimiter(b'|');
-//             ctx.register_csv(table, &format!("{}/{}.tbl", tpch_data, table), options)?;
-//         }
-//
-//         let plan = ctx.sql(
-//             "select
-//     l_shipmode,
-//     sum(case
-//             when o_orderpriority = '1-URGENT'
-//                 or o_orderpriority = '2-HIGH'
-//                 then 1
-//             else 0
-//         end) as high_line_count,
-//     sum(case
-//             when o_orderpriority <> '1-URGENT'
-//                 and o_orderpriority <> '2-HIGH'
-//                 then 1
-//             else 0
-//         end) as low_line_count
-// from
-//     lineitem
-//         join
-//     orders
-//     on
-//             l_orderkey = o_orderkey
-// group by
-//     l_shipmode
-// order by
-//     l_shipmode",
-//         )?;
-//
-//         /*
-//               where
-//               l_shipmode in ('MAIL', 'SHIP')
-//         and l_commitdate < l_receiptdate
-//         and l_shipdate < l_commitdate
-//         and l_receiptdate >= date '1994-01-01'
-//         and l_receiptdate < date '1995-01-01'
-//
-//                */
-//         let df = ExecutionContext::new();
-//         let plan = df.optimize(&plan.to_logical_plan())?;
-//         let plan = df.create_physical_plan(&plan)?;
-//
-//         let executors = vec![ExecutorMeta {
-//             id: "TBD".to_string(),
-//             host: "localhost".to_string(),
-//             port: 50051,
-//         }];
-//
-//         let mut planner = DistributedPlanner::new(Box::new(executors));
-//         planner.execute_distributed_query(plan).await?;
-//
-//         Ok(())
-//     }
-//
-//     fn get_schema(table: &str) -> Schema {
-//         // note that the schema intentionally uses signed integers so that any generated Parquet
-//         // files can also be used to benchmark tools that only support signed integers, such as
-//         // Apache Spark
-//
-//         match table {
-//             "part" => Schema::new(vec![
-//                 Field::new("p_partkey", DataType::Int32, false),
-//                 Field::new("p_name", DataType::Utf8, false),
-//                 Field::new("p_mfgr", DataType::Utf8, false),
-//                 Field::new("p_brand", DataType::Utf8, false),
-//                 Field::new("p_type", DataType::Utf8, false),
-//                 Field::new("p_size", DataType::Int32, false),
-//                 Field::new("p_container", DataType::Utf8, false),
-//                 Field::new("p_retailprice", DataType::Float64, false),
-//                 Field::new("p_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "supplier" => Schema::new(vec![
-//                 Field::new("s_suppkey", DataType::Int32, false),
-//                 Field::new("s_name", DataType::Utf8, false),
-//                 Field::new("s_address", DataType::Utf8, false),
-//                 Field::new("s_nationkey", DataType::Int32, false),
-//                 Field::new("s_phone", DataType::Utf8, false),
-//                 Field::new("s_acctbal", DataType::Float64, false),
-//                 Field::new("s_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "partsupp" => Schema::new(vec![
-//                 Field::new("ps_partkey", DataType::Int32, false),
-//                 Field::new("ps_suppkey", DataType::Int32, false),
-//                 Field::new("ps_availqty", DataType::Int32, false),
-//                 Field::new("ps_supplycost", DataType::Float64, false),
-//                 Field::new("ps_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "customer" => Schema::new(vec![
-//                 Field::new("c_custkey", DataType::Int32, false),
-//                 Field::new("c_name", DataType::Utf8, false),
-//                 Field::new("c_address", DataType::Utf8, false),
-//                 Field::new("c_nationkey", DataType::Int32, false),
-//                 Field::new("c_phone", DataType::Utf8, false),
-//                 Field::new("c_acctbal", DataType::Float64, false),
-//                 Field::new("c_mktsegment", DataType::Utf8, false),
-//                 Field::new("c_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "orders" => Schema::new(vec![
-//                 Field::new("o_orderkey", DataType::Int32, false),
-//                 Field::new("o_custkey", DataType::Int32, false),
-//                 Field::new("o_orderstatus", DataType::Utf8, false),
-//                 Field::new("o_totalprice", DataType::Float64, false),
-//                 Field::new("o_orderdate", DataType::Date32, false),
-//                 Field::new("o_orderpriority", DataType::Utf8, false),
-//                 Field::new("o_clerk", DataType::Utf8, false),
-//                 Field::new("o_shippriority", DataType::Int32, false),
-//                 Field::new("o_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "lineitem" => Schema::new(vec![
-//                 Field::new("l_orderkey", DataType::Int32, false),
-//                 Field::new("l_partkey", DataType::Int32, false),
-//                 Field::new("l_suppkey", DataType::Int32, false),
-//                 Field::new("l_linenumber", DataType::Int32, false),
-//                 Field::new("l_quantity", DataType::Float64, false),
-//                 Field::new("l_extendedprice", DataType::Float64, false),
-//                 Field::new("l_discount", DataType::Float64, false),
-//                 Field::new("l_tax", DataType::Float64, false),
-//                 Field::new("l_returnflag", DataType::Utf8, false),
-//                 Field::new("l_linestatus", DataType::Utf8, false),
-//                 Field::new("l_shipdate", DataType::Date32, false),
-//                 Field::new("l_commitdate", DataType::Date32, false),
-//                 Field::new("l_receiptdate", DataType::Date32, false),
-//                 Field::new("l_shipinstruct", DataType::Utf8, false),
-//                 Field::new("l_shipmode", DataType::Utf8, false),
-//                 Field::new("l_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "nation" => Schema::new(vec![
-//                 Field::new("n_nationkey", DataType::Int32, false),
-//                 Field::new("n_name", DataType::Utf8, false),
-//                 Field::new("n_regionkey", DataType::Int32, false),
-//                 Field::new("n_comment", DataType::Utf8, false),
-//             ]),
-//
-//             "region" => Schema::new(vec![
-//                 Field::new("r_regionkey", DataType::Int32, false),
-//                 Field::new("r_name", DataType::Utf8, false),
-//                 Field::new("r_comment", DataType::Utf8, false),
-//             ]),
-//
-//             _ => unimplemented!(),
-//         }
-//     }
-// }


### PR DESCRIPTION
The example query gets transformed into this query plan:

```
QueryStageExec { job_uuid: c20cd182-2792-457b-a4d0-a24b0939b
  ProjectionExec { expr: [(Column { name: "l_shipmode" }, "l_s
    CoalesceBatchesExec { input: HashJoinExec { left: QueryStage
      HashJoinExec { left: QueryStageExec { job_uuid: c20cd182-279
        QueryStageExec { job_uuid: c20cd182-2792-457b-a4d0-a24b0939b
          CsvExec { path: "/home/andy/git/ballista/benchmarks/tpch/dat
        QueryStageExec { job_uuid: c20cd182-2792-457b-a4d0-a24b0939b
          CsvExec { path: "/home/andy/git/ballista/benchmarks/tpch/dat
```

The two leaf node query stages get executed against the executors and the next query stage looks like this:

```
ProjectionExec { expr: [(Column { name: "l_shipmode" }, "l_s
  CoalesceBatchesExec { input: HashJoinExec { left: ShuffleRea
    HashJoinExec { left: ShuffleReaderExec { partition_meta: [Pa
      ShuffleReaderExec { partition_meta: [PartitionLocation { par
      ShuffleReaderExec { partition_meta: [PartitionLocation { par
```

This fails to execute because `physical plan to_proto unsupported plan ShuffleReaderExec` (https://github.com/ballista-compute/ballista/issues/470)

