### PR TITLE
Use --no-cache when building Docker image

### DIFF
--- a/dev/build-rust.sh
+++ b/dev/build-rust.sh
@@ -7,4 +7,4 @@ set -e
 # Rust proto is ahead of top level proto - see https://github.com/ballista-compute/ballista/issues/374
 #cp -f proto/ballista.proto rust/ballista/proto/
 
-docker build -t ballistacompute/ballista-rust:$BALLISTA_VERSION -f docker/rust.dockerfile .
+docker build --no-cache -t ballistacompute/ballista-rust:$BALLISTA_VERSION -f docker/rust.dockerfile .

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.36"
 clap = "2"
 crossbeam = "0.7"
 env_logger = "0.8"
-etcd-client = "0.5"
+etcd-client = "0.6"
 futures = "0.3"
 k8s-openapi = { version = "0.8.0", features = ["v1_13"] }
 kube = "0.35"


### PR DESCRIPTION
Closes https://github.com/ballista-compute/ballista/issues/495

I suspect the cached docker layers had old versions of crates that somehow were being picked up in the build. This PR is a quick fix but isn't ideal since it will be really slow to build the docker image now.

```bash
h$ docker-compose up
WARNING: Found orphan containers (tpch_ballista-rust_1, tpch_scheduler_1, tpch_executor_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Starting tpch_etcd_1 ... done
Recreating tpch_ballista-scheduler_1 ... done
Recreating tpch_ballista-executor_1  ... done
Attaching to tpch_etcd_1, tpch_ballista-scheduler_1, tpch_ballista-executor_1
ballista-executor_1   | [2021-02-11T15:04:38Z INFO  executor] Running with config: ExecutorConfig { host: "localhost", port: 50051, work_dir: "/tmp/.tmpB7mZVD", concurrent_tasks: 4 }
ballista-executor_1   | [2021-02-11T15:04:38Z INFO  executor] Ballista v0.4.0-SNAPSHOT Rust Executor listening on 0.0.0.0:50051
ballista-executor_1   | [2021-02-11T15:04:38Z INFO  executor] Starting registration with scheduler
ballista-scheduler_1  | [2021-02-11T15:04:38Z INFO  scheduler] Ballista v0.4.0-SNAPSHOT Scheduler listening on 0.0.0.0:50050
ballista-scheduler_1  | [2021-02-11T15:04:38Z INFO  ballista::scheduler] Received register_executor request for ExecutorMetadata { id: "808aad32-0190-48b2-93f8-2a3b9f28161b", host: "localhost", port: 50051 }
etcd_1                | [WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
etcd_1                | 2021-02-11 15:04:37.581680 I | etcdmain: etcd Version: 3.4.9
etcd_1                | 2021-02-11 15:04:37.581727 I | etcdmain: Git SHA: 54ba95891
etcd_1                | 2021-02-11 15:04:37.581732 I | etcdmain: Go Version: go1.12.17
etcd_1                | 2021-02-11 15:04:37.581738 I | etcdmain: Go OS/Arch: linux/amd64
etcd_1                | 2021-02-11 15:04:37.581744 I | etcdmain: setting maximum number of CPUs to 48, total number of available CPUs is 48
etcd_1                | 2021-02-11 15:04:37.581755 W | etcdmain: no data-dir provided, using default data-dir ./default.etcd
etcd_1                | 2021-02-11 15:04:37.581955 N | etcdmain: the server is already initialized as member before, starting as etcd member...
etcd_1                | [WARNING] Deprecated '--logger=capnslog' flag is set; use '--logger=zap' flag instead
etcd_1                | 2021-02-11 15:04:37.583367 I | embed: name = default
etcd_1                | 2021-02-11 15:04:37.583378 I | embed: data dir = default.etcd
etcd_1                | 2021-02-11 15:04:37.583383 I | embed: member dir = default.etcd/member
etcd_1                | 2021-02-11 15:04:37.583387 I | embed: heartbeat = 100ms
etcd_1                | 2021-02-11 15:04:37.583393 I | embed: election = 1000ms
etcd_1                | 2021-02-11 15:04:37.583397 I | embed: snapshot count = 100000
etcd_1                | 2021-02-11 15:04:37.583407 I | embed: advertise client URLs = http://etcd:2379
etcd_1                | 2021-02-11 15:04:37.583413 I | embed: initial advertise peer URLs = http://localhost:2380
etcd_1                | 2021-02-11 15:04:37.583420 I | embed: initial cluster = 
etcd_1                | 2021-02-11 15:04:37.586805 I | etcdserver: restarting member 8e9e05c52164694d in cluster cdf818194e3a8c32 at commit index 6
etcd_1                | raft2021/02/11 15:04:37 INFO: 8e9e05c52164694d switched to configuration voters=()
etcd_1                | raft2021/02/11 15:04:37 INFO: 8e9e05c52164694d became follower at term 3
etcd_1                | raft2021/02/11 15:04:37 INFO: newRaft 8e9e05c52164694d [peers: [], term: 3, commit: 6, applied: 0, lastindex: 6, lastterm: 3]
etcd_1                | 2021-02-11 15:04:37.599998 W | auth: simple token is not cryptographically signed
etcd_1                | 2021-02-11 15:04:37.612103 I | etcdserver: starting server... [version: 3.4.9, cluster version: to_be_decided]
etcd_1                | raft2021/02/11 15:04:37 INFO: 8e9e05c52164694d switched to configuration voters=(10276657743932975437)
etcd_1                | 2021-02-11 15:04:37.615476 I | etcdserver/membership: added member 8e9e05c52164694d [http://localhost:2380] to cluster cdf818194e3a8c32
etcd_1                | 2021-02-11 15:04:37.615625 N | etcdserver/membership: set the initial cluster version to 3.4
etcd_1                | 2021-02-11 15:04:37.615693 I | etcdserver/api: enabled capabilities for version 3.4
etcd_1                | 2021-02-11 15:04:37.616441 I | embed: listening for peers on 127.0.0.1:2380
etcd_1                | raft2021/02/11 15:04:39 INFO: 8e9e05c52164694d is starting a new election at term 3
etcd_1                | raft2021/02/11 15:04:39 INFO: 8e9e05c52164694d became candidate at term 4
etcd_1                | raft2021/02/11 15:04:39 INFO: 8e9e05c52164694d received MsgVoteResp from 8e9e05c52164694d at term 4
etcd_1                | raft2021/02/11 15:04:39 INFO: 8e9e05c52164694d became leader at term 4
etcd_1                | raft2021/02/11 15:04:39 INFO: raft.node: 8e9e05c52164694d elected leader 8e9e05c52164694d at term 4
etcd_1                | 2021-02-11 15:04:39.489223 I | embed: ready to serve client requests
etcd_1                | 2021-02-11 15:04:39.489343 I | etcdserver: published {Name:default ClientURLs:[http://etcd:2379]} to cluster cdf818194e3a8c32
etcd_1                | 2021-02-11 15:04:39.495923 N | embed: serving insecure client requests on [::]:2379, this is strongly discouraged!
ballista-executor_1   | [2021-02-11T15:04:54Z INFO  executor] Starting registration with scheduler
ballista-scheduler_1  | [2021-02-11T15:04:54Z INFO  ballista::scheduler] Received register_executor request for ExecutorMetadata { id: "808aad32-0190-48b2-93f8-2a3b9f28161b", host: "localhost", port: 50051 }
```