### PR TITLE
Fix HashAggregateExec

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -87,7 +87,6 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=c3b972c#c3b972c8f7005e037bdb183914ad0853cd7f9cf5"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -110,7 +109,6 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=c3b972c#c3b972c8f7005e037bdb183914ad0853cd7f9cf5"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -207,7 +205,7 @@ dependencies = [
  "rand 0.8.3",
  "sled",
  "snmalloc-rs",
- "sqlparser",
+ "sqlparser 0.7.0",
  "structopt",
  "tempfile",
  "tokio 1.2.0",
@@ -592,7 +590,6 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=c3b972c#c3b972c8f7005e037bdb183914ad0853cd7f9cf5"
 dependencies = [
  "ahash 0.7.0",
  "arrow",
@@ -611,7 +608,7 @@ dependencies = [
  "pin-project-lite 0.2.4",
  "rustyline",
  "sha2",
- "sqlparser",
+ "sqlparser 0.8.0",
  "tokio 1.2.0",
 ]
 
@@ -1744,7 +1741,6 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=c3b972c#c3b972c8f7005e037bdb183914ad0853cd7f9cf5"
 dependencies = [
  "arrow",
  "base64 0.12.3",
@@ -2446,6 +2442,15 @@ name = "sqlparser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a3da41f3ddf62cbf92635ace62dd037fad9a91c6871c514fbd404e2059f27d"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b929a9577d01ee7cddb820696ed536868d81557d3c14363a7514d71add1d058"
 dependencies = [
  "log",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -87,6 +87,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=7660a22#7660a22090fcf1d0230ca1e700a4b98f647b0c48"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -109,6 +110,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=7660a22#7660a22090fcf1d0230ca1e700a4b98f647b0c48"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -590,6 +592,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=7660a22#7660a22090fcf1d0230ca1e700a4b98f647b0c48"
 dependencies = [
  "ahash 0.7.0",
  "arrow",
@@ -1741,6 +1744,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=7660a22#7660a22090fcf1d0230ca1e700a4b98f647b0c48"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -36,9 +36,9 @@ tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tonic = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-arrow = { path = "../../../arrow/rust/arrow" }
-arrow-flight = { path = "../../../arrow/rust/arrow-flight" }
-datafusion = { path = "../../../arrow/rust/datafusion" }
+arrow = { git = "https://github.com/apache/arrow", rev="7660a22" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="7660a22" }
+datafusion = { git = "https://github.com/apache/arrow", rev="7660a22" }
 
 
 [dev-dependencies]

--- a/rust/ballista/Cargo.toml
+++ b/rust/ballista/Cargo.toml
@@ -36,9 +36,9 @@ tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tonic = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-arrow = { git = "https://github.com/apache/arrow", rev="c3b972c" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="c3b972c" }
-datafusion = { git = "https://github.com/apache/arrow", rev="c3b972c" }
+arrow = { path = "../../../arrow/rust/arrow" }
+arrow-flight = { path = "../../../arrow/rust/arrow-flight" }
+datafusion = { path = "../../../arrow/rust/datafusion" }
 
 
 [dev-dependencies]

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -350,6 +350,7 @@ message EmptyExecNode {
 message ProjectionExecNode {
   PhysicalPlanNode input = 1;
   repeated LogicalExprNode expr = 2;
+  repeated string expr_name = 3;
 }
 
 message SelectionExecNode {

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -367,6 +367,8 @@ message HashAggregateExecNode {
   AggregateMode mode = 3;
   PhysicalPlanNode input = 4;
   repeated string group_expr_name = 5;
+  // we need the input schema to the partial aggregate to pass to the final aggregate
+  Schema input_schema = 6;
 }
 
 message ShuffleReaderExecNode {

--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -366,6 +366,7 @@ message HashAggregateExecNode {
   repeated LogicalExprNode aggr_expr = 2;
   AggregateMode mode = 3;
   PhysicalPlanNode input = 4;
+  repeated string group_expr_name = 5;
 }
 
 message ShuffleReaderExecNode {

--- a/rust/ballista/src/serde/physical_plan/mod.rs
+++ b/rust/ballista/src/serde/physical_plan/mod.rs
@@ -99,13 +99,14 @@ mod roundtrip_tests {
 
         let field_a = Field::new("a", DataType::Int64, false);
         let field_b = Field::new("b", DataType::Int64, false);
-        let schema = Schema::new(vec![field_a, field_b]);
+        let schema = Arc::new(Schema::new(vec![field_a, field_b]));
 
         roundtrip_test(Arc::new(HashAggregateExec::try_new(
             AggregateMode::Final,
             groups.clone(),
             aggregates.clone(),
-            Arc::new(EmptyExec::new(false, Arc::new(schema))),
+            Arc::new(EmptyExec::new(false, schema.clone())),
+            schema,
         )?))
     }
 }

--- a/rust/ballista/src/serde/physical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/physical_plan/to_proto.rs
@@ -152,6 +152,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                 AggregateMode::Partial => protobuf::AggregateMode::Partial,
                 AggregateMode::Final => protobuf::AggregateMode::Final,
             };
+            let input_schema = exec.input_schema();
             let input: protobuf::PhysicalPlanNode = exec.input().to_owned().try_into()?;
             Ok(protobuf::PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::HashAggregate(Box::new(
@@ -161,6 +162,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                         aggr_expr: agg,
                         mode: agg_mode as i32,
                         input: Some(Box::new(input)),
+                        input_schema: Some(input_schema.as_ref().into()),
                     },
                 ))),
             })

--- a/rust/ballista/src/serde/physical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/physical_plan/to_proto.rs
@@ -68,11 +68,13 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                 .iter()
                 .map(|expr| expr.0.clone().try_into())
                 .collect::<Result<Vec<_>, Self::Error>>()?;
+            let expr_name = exec.expr().iter().map(|expr| expr.1.clone()).collect();
             Ok(protobuf::PhysicalPlanNode {
                 physical_plan_type: Some(PhysicalPlanType::Projection(Box::new(
                     protobuf::ProjectionExecNode {
                         input: Some(Box::new(input)),
                         expr,
+                        expr_name,
                     },
                 ))),
             })

--- a/rust/ballista/src/serde/physical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/physical_plan/to_proto.rs
@@ -138,6 +138,11 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                 .iter()
                 .map(|expr| expr.0.to_owned().try_into())
                 .collect::<Result<Vec<_>, BallistaError>>()?;
+            let group_names = exec
+                .group_expr()
+                .iter()
+                .map(|expr| expr.1.to_owned())
+                .collect();
             let agg = exec
                 .aggr_expr()
                 .iter()
@@ -152,6 +157,7 @@ impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
                 physical_plan_type: Some(PhysicalPlanType::HashAggregate(Box::new(
                     protobuf::HashAggregateExecNode {
                         group_expr: groups,
+                        group_expr_name: group_names,
                         aggr_expr: agg,
                         mode: agg_mode as i32,
                         input: Some(Box::new(input)),

--- a/rust/benchmarks/tpch/Cargo.toml
+++ b/rust/benchmarks/tpch/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2018"
 [dependencies]
 ballista = { path="../../ballista" }
 
-arrow = { git = "https://github.com/apache/arrow", rev="c3b972c" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="c3b972c" }
-datafusion = { git = "https://github.com/apache/arrow", rev="c3b972c" }
-parquet = { git = "https://github.com/apache/arrow", rev="c3b972c" }
+arrow = { path = "../../../../arrow/rust/arrow" }
+arrow-flight = { path = "../../../../arrow/rust/arrow-flight" }
+datafusion = { path = "../../../../arrow/rust/datafusion" }
+parquet = { path = "../../../../arrow/rust/parquet" }
+
 
 env_logger = "0.8"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }

--- a/rust/benchmarks/tpch/Cargo.toml
+++ b/rust/benchmarks/tpch/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 ballista = { path="../../ballista" }
 
-arrow = { path = "../../../../arrow/rust/arrow" }
-arrow-flight = { path = "../../../../arrow/rust/arrow-flight" }
-datafusion = { path = "../../../../arrow/rust/datafusion" }
-parquet = { path = "../../../../arrow/rust/parquet" }
+arrow = { git = "https://github.com/apache/arrow", rev="7660a22" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="7660a22" }
+datafusion = { git = "https://github.com/apache/arrow", rev="7660a22" }
+parquet = { git = "https://github.com/apache/arrow", rev="7660a22" }
 
 
 env_logger = "0.8"


### PR DESCRIPTION
This PR fixes two bugs:

1. We were not persisting the names for the group by expressions
2. We needed to persist the input schema before any aggregates are applied


This depends on https://github.com/apache/arrow/pull/9481

Closes https://github.com/ballista-compute/ballista/issues/504

```
Running benchmark with query 12:
 select
    l_shipmode,
    sum(case
            when o_orderpriority = '1-URGENT'
                or o_orderpriority = '2-HIGH'
                then 1
            else 0
        end) as high_line_count,
    sum(case
            when o_orderpriority <> '1-URGENT'
                and o_orderpriority <> '2-HIGH'
                then 1
            else 0
        end) as low_line_count
from
    lineitem
        join
    orders
    on
            l_orderkey = o_orderkey
where
        l_shipmode in ('MAIL', 'SHIP')
  and l_commitdate < l_receiptdate
  and l_shipdate < l_commitdate
  and l_receiptdate >= date '1994-01-01'
  and l_receiptdate < date '1995-01-01'
group by
    l_shipmode
order by
    l_shipmode;
[2021-02-12T23:56:13Z INFO  ballista::context] Connecting to Ballista scheduler at http://localhost:50050
[2021-02-12T23:56:13Z INFO  ballista::context] Job quQuUWY is running...
[2021-02-12T23:56:18Z INFO  ballista::context] Job quQuUWY is running...
+------------+-----------------+----------------+
| l_shipmode | high_line_count | low_line_count |
+------------+-----------------+----------------+
| MAIL       | 6202            | 9324           |
| SHIP       | 6200            | 9262           |
+------------+-----------------+----------------+
Query 12 iteration 0 took 10026.5 ms
```

