### PR TITLE
Docker refactor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 **/target
 **/build
+**/.idea
+docs

--- a/dev/build-rust-base.sh
+++ b/dev/build-rust-base.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+BALLISTA_VERSION=0.4.0-SNAPSHOT
+set -e
+docker build -t ballistacompute/rust-base:$BALLISTA_VERSION -f docker/rust-base.dockerfile .

--- a/dev/build-rust.sh
+++ b/dev/build-rust.sh
@@ -7,4 +7,4 @@ set -e
 # Rust proto is ahead of top level proto - see https://github.com/ballista-compute/ballista/issues/374
 #cp -f proto/ballista.proto rust/ballista/proto/
 
-docker build --no-cache -t ballistacompute/ballista-rust:$BALLISTA_VERSION -f docker/rust.dockerfile .
+docker build -t ballistacompute/ballista-rust:$BALLISTA_VERSION -f docker/rust.dockerfile .

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -1,0 +1,75 @@
+# Base image extends debian:buster-slim
+FROM rust:1.49.0-buster AS builder
+
+RUN apt update && apt -y install musl musl-dev musl-tools libssl-dev openssl
+
+#NOTE: the following was copied from https://github.com/emk/rust-musl-builder/blob/master/Dockerfile under Apache 2.0 license
+
+# The OpenSSL version to use. We parameterize this because many Rust
+# projects will fail to build with 1.1.
+#ARG OPENSSL_VERSION=1.0.2r
+ARG OPENSSL_VERSION=1.1.1b
+
+# Build a static library version of OpenSSL using musl-libc.  This is needed by
+# the popular Rust `hyper` crate.
+#
+# We point /usr/local/musl/include/linux at some Linux kernel headers (not
+# necessarily the right ones) in an effort to compile OpenSSL 1.1's "engine"
+# component. It's possible that this will cause bizarre and terrible things to
+# happen. There may be "sanitized" header
+RUN echo "Building OpenSSL" && \
+    ls /usr/include/linux && \
+    mkdir -p /usr/local/musl/include && \
+    ln -s /usr/include/linux /usr/local/musl/include/linux && \
+    ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm && \
+    ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic && \
+    cd /tmp && \
+    curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
+    tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
+    env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
+    env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
+    env C_INCLUDE_PATH=/usr/local/musl/include/ make && \
+    make install && \
+    rm /usr/local/musl/include/linux /usr/local/musl/include/asm /usr/local/musl/include/asm-generic && \
+    rm -r /tmp/*
+
+RUN echo "Building zlib" && \
+    cd /tmp && \
+    ZLIB_VERSION=1.2.11 && \
+    curl -LO "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" && \
+    tar xzf "zlib-$ZLIB_VERSION.tar.gz" && cd "zlib-$ZLIB_VERSION" && \
+    CC=musl-gcc ./configure --static --prefix=/usr/local/musl && \
+    make && make install && \
+    rm -r /tmp/*
+
+RUN echo "Building libpq" && \
+    cd /tmp && \
+    POSTGRESQL_VERSION=11.2 && \
+    curl -LO "https://ftp.postgresql.org/pub/source/v$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.tar.gz" && \
+    tar xzf "postgresql-$POSTGRESQL_VERSION.tar.gz" && cd "postgresql-$POSTGRESQL_VERSION" && \
+    CC=musl-gcc CPPFLAGS=-I/usr/local/musl/include LDFLAGS=-L/usr/local/musl/lib ./configure --with-openssl --without-readline --prefix=/usr/local/musl && \
+    cd src/interfaces/libpq && make all-static-lib && make install-lib-static && \
+    cd ../../bin/pg_config && make && make install && \
+    rm -r /tmp/*
+
+ENV OPENSSL_DIR=/usr/local/musl/ \
+    OPENSSL_INCLUDE_DIR=/usr/local/musl/include/ \
+    DEP_OPENSSL_INCLUDE=/usr/local/musl/include/ \
+    OPENSSL_LIB_DIR=/usr/local/musl/lib/ \
+    OPENSSL_STATIC=1 \
+    PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=1 \
+    PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
+    PKG_CONFIG_ALLOW_CROSS=true \
+    PKG_CONFIG_ALL_STATIC=true \
+    LIBZ_SYS_STATIC=1 \
+    TARGET=musl
+
+# The content copied mentioned in the NOTE above ends here.
+
+## Download the target for static linking.
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo install cargo-build-deps
+
+# prepare toolchain
+RUN rustup update && \
+    rustup component add rustfmt

--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -1,78 +1,4 @@
-# Base image extends debian:buster-slim
-FROM rust:1.49.0-buster AS builder
-
-RUN apt update && apt -y install musl musl-dev musl-tools libssl-dev openssl
-
-#NOTE: the following was copied from https://github.com/emk/rust-musl-builder/blob/master/Dockerfile under Apache 2.0 license
-
-# The OpenSSL version to use. We parameterize this because many Rust
-# projects will fail to build with 1.1.
-#ARG OPENSSL_VERSION=1.0.2r
-ARG OPENSSL_VERSION=1.1.1b
-
-# Build a static library version of OpenSSL using musl-libc.  This is needed by
-# the popular Rust `hyper` crate.
-#
-# We point /usr/local/musl/include/linux at some Linux kernel headers (not
-# necessarily the right ones) in an effort to compile OpenSSL 1.1's "engine"
-# component. It's possible that this will cause bizarre and terrible things to
-# happen. There may be "sanitized" header
-RUN echo "Building OpenSSL" && \
-    ls /usr/include/linux && \
-    mkdir -p /usr/local/musl/include && \
-    ln -s /usr/include/linux /usr/local/musl/include/linux && \
-    ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm && \
-    ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic && \
-    cd /tmp && \
-    curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
-    tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
-    env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
-    env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
-    env C_INCLUDE_PATH=/usr/local/musl/include/ make && \
-    make install && \
-    rm /usr/local/musl/include/linux /usr/local/musl/include/asm /usr/local/musl/include/asm-generic && \
-    rm -r /tmp/*
-
-RUN echo "Building zlib" && \
-    cd /tmp && \
-    ZLIB_VERSION=1.2.11 && \
-    curl -LO "http://zlib.net/zlib-$ZLIB_VERSION.tar.gz" && \
-    tar xzf "zlib-$ZLIB_VERSION.tar.gz" && cd "zlib-$ZLIB_VERSION" && \
-    CC=musl-gcc ./configure --static --prefix=/usr/local/musl && \
-    make && make install && \
-    rm -r /tmp/*
-
-RUN echo "Building libpq" && \
-    cd /tmp && \
-    POSTGRESQL_VERSION=11.2 && \
-    curl -LO "https://ftp.postgresql.org/pub/source/v$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.tar.gz" && \
-    tar xzf "postgresql-$POSTGRESQL_VERSION.tar.gz" && cd "postgresql-$POSTGRESQL_VERSION" && \
-    CC=musl-gcc CPPFLAGS=-I/usr/local/musl/include LDFLAGS=-L/usr/local/musl/lib ./configure --with-openssl --without-readline --prefix=/usr/local/musl && \
-    cd src/interfaces/libpq && make all-static-lib && make install-lib-static && \
-    cd ../../bin/pg_config && make && make install && \
-    rm -r /tmp/*
-
-ENV OPENSSL_DIR=/usr/local/musl/ \
-    OPENSSL_INCLUDE_DIR=/usr/local/musl/include/ \
-    DEP_OPENSSL_INCLUDE=/usr/local/musl/include/ \
-    OPENSSL_LIB_DIR=/usr/local/musl/lib/ \
-    OPENSSL_STATIC=1 \
-    PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=1 \
-    PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
-    PKG_CONFIG_ALLOW_CROSS=true \
-    PKG_CONFIG_ALL_STATIC=true \
-    LIBZ_SYS_STATIC=1 \
-    TARGET=musl
-
-# The content copied mentioned in the NOTE above ends here.
-
-## Download the target for static linking.
-RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo install cargo-build-deps
-
-# prepare toolchain
-RUN rustup update && \
-    rustup component add rustfmt
+FROM ballistacompute/rust-base:0.4.0-20210213 AS builder
 
 # Fetch Ballista dependencies
 COPY rust/ballista/Cargo.toml /tmp/ballista/
@@ -109,7 +35,7 @@ ENV RELEASE_FLAG=${RELEASE_FLAG}
 RUN if [ -z "$RELEASE_FLAG" ]; then mv /tmp/ballista/target/debug/scheduler /scheduler; else mv /tmp/ballista/target/release/scheduler /scheduler; fi
 
 # Copy the binary into a new container for a smaller docker image
-FROM debian:buster-slim
+FROM ballistacompute/rust-base:0.4.0-20210213
 
 COPY --from=builder /executor /
 


### PR DESCRIPTION
This PR splits the Dockerfile into two parts:

1 rust-base.Dockerfile which contains Rust and no Ballista components. This Dockerfile changes rarely and I have pushed a tagged version to Dockerhub
2. Ballista Rust image which extends the base image