### PR TITLE
Add integration test script

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,8 @@ jobs:
     - name: Generate benchmark data
       run: cd benchmarks/tpch && ./tpch-gen.sh
     - name: Move benchmark data
-      # hack to make benchmark and scheduler paths match up
+      # hack to make benchmark and scheduler paths identical until
+      # https://github.com/ballista-compute/ballista/issues/473 is implemented
       run: mkdir /data && mv data/*.tbl /data
     - name: Run integration tests
-      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50050 --query 12 --path /data --format tbl
+      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50050 --query 12 --path /data --format tbl --iterations 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,9 +142,9 @@ jobs:
       if: github.event_name != 'pull_request'
       run: docker push $IMAGE_NAME:${{ steps.extract_ref.outputs.ref }}
 
-  IntegrationTests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Run integration tests
-      run: bash dev/integration-tests.sh
+#  IntegrationTests:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Run integration tests
+#      run: bash dev/integration-tests.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,21 +146,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Build images
-      run: bash dev/build-rust.sh
-    - name: Build benchmarks
-      run: cd benchmarks/tpch && cargo build
-    - name: Build integration test stack
-      run: cd benchmarks/tpch && docker-compose up -d
-    - name: Wait for executors to start
-      uses: jakejarvis/wait-action@master
-      with:
-        time: "20s"
-    - name: Generate benchmark data
-      run: cd benchmarks/tpch && ./tpch-gen.sh
-    - name: Move benchmark data
-      # hack to make benchmark and scheduler paths identical until
-      # https://github.com/ballista-compute/ballista/issues/473 is implemented
-      run: mkdir /data && mv data/*.tbl /data
     - name: Run integration tests
-      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50050 --query 12 --path /data --format tbl --iterations 1
+      run: bash dev/integration-tests.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,21 +142,24 @@ jobs:
       if: github.event_name != 'pull_request'
       run: docker push $IMAGE_NAME:${{ steps.extract_ref.outputs.ref }}
 
-#  IntegrationTests:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Build images
-#      run: bash dev/build-rust.sh
-#    - name: Build benchmarks
-#      run: cd benchmarks/tpch && cargo build
-#    - name: Build integration test stack
-#      run: cd benchmarks/tpch && docker-compose up -d
-#    - name: Wait for executors to start
-#      uses: jakejarvis/wait-action@master
-#      with:
-#        time: "20s"
-#    - Generate TPC-H data
-#      run: cd benchmarks/tpch && ./tpch-gen.sh
-#    - name: Run integration tests
-#      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50051 --query 12 --path data --format tbl
+  IntegrationTests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build images
+      run: bash dev/build-rust.sh
+    - name: Build benchmarks
+      run: cd benchmarks/tpch && cargo build
+    - name: Build integration test stack
+      run: cd benchmarks/tpch && docker-compose up -d
+    - name: Wait for executors to start
+      uses: jakejarvis/wait-action@master
+      with:
+        time: "20s"
+    - Generate benchmark data
+      run: cd benchmarks/tpch && ./tpch-gen.sh
+    - Move benchmark data
+      # hack to make benchmark and scheduler paths match up
+      run: mkdir /data && mv data/*.tbl /data
+    - name: Run integration tests
+      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50050 --query 12 --path data --format tbl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -156,10 +156,10 @@ jobs:
       uses: jakejarvis/wait-action@master
       with:
         time: "20s"
-    - Generate benchmark data
+    - name: Generate benchmark data
       run: cd benchmarks/tpch && ./tpch-gen.sh
-    - Move benchmark data
+    - name: Move benchmark data
       # hack to make benchmark and scheduler paths match up
       run: mkdir /data && mv data/*.tbl /data
     - name: Run integration tests
-      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50050 --query 12 --path data --format tbl
+      run: cd benchmarks/tpch && cargo run benchmark --host localhost --port 50050 --query 12 --path /data --format tbl

--- a/dev/integration-tests.sh
+++ b/dev/integration-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+./dev/build-rust.sh
+pushd rust/benchmarks/tpch
+./tpch-gen.sh
+
+# hack to make benchmark and scheduler paths identical until
+# https://github.com/ballista-compute/ballista/issues/473 is implemented
+mkdir /data 2>/dev/null
+cp data/*.tbl /data
+
+docker-compose up -d
+sleep 10
+cargo run benchmark --host localhost --port 50050 --query 12 --path /data --format tbl --iterations 1
+docker-compose down
+
+popd

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -1,6 +1,14 @@
 # Integration Testing
 
 Ballista has a [benchmark crate](https://github.com/ballista-compute/ballista/tree/main/rust/benchmarks/tpch) which is
-based on TPC-H and this is currently the main form of integration testing. Please refer to the 
+derived from TPC-H and this is currently the main form of integration testing. 
+
+The following command can be used to run the integration tests.
+
+```bash
+./dev/integration-tests.sh
+```
+
+Please refer to the
 [benchmark documentation](https://github.com/ballista-compute/ballista/blob/main/rust/benchmarks/tpch/README.md)
 for more information.

--- a/rust/ballista/src/scheduler/mod.rs
+++ b/rust/ballista/src/scheduler/mod.rs
@@ -188,8 +188,7 @@ impl<T: ConfigBackendClient + Send + Sync + 'static> SchedulerGrpc for Scheduler
                     .optimize(&plan)
                     .and_then(|plan| datafusion_ctx.create_physical_plan(&plan))
                     .map_err(|e| {
-                        let msg =
-                            format!("Could not create physical plan: {}", e);
+                        let msg = format!("Could not create physical plan: {}", e);
                         error!("{}", msg);
                         tonic::Status::internal(msg)
                     }));

--- a/rust/ballista/src/scheduler/mod.rs
+++ b/rust/ballista/src/scheduler/mod.rs
@@ -189,7 +189,7 @@ impl<T: ConfigBackendClient + Send + Sync + 'static> SchedulerGrpc for Scheduler
                     .and_then(|plan| datafusion_ctx.create_physical_plan(&plan))
                     .map_err(|e| {
                         let msg =
-                            format!("Could not retrieve data from configuration store: {}", e);
+                            format!("Could not create physical plan: {}", e);
                         error!("{}", msg);
                         tonic::Status::internal(msg)
                     }));

--- a/rust/benchmarks/tpch/README.md
+++ b/rust/benchmarks/tpch/README.md
@@ -55,7 +55,7 @@ docker-compose up
 To run the benchmarks:
 
 ```bash
-cargo run benchmark --host localhost --port 50051 --query 1 --path $(pwd)/data --format tbl
+cargo run benchmark --host localhost --port 50050 --query 1 --path $(pwd)/data --format tbl
 ```
 
 This should produce the following output:

--- a/rust/benchmarks/tpch/docker-compose.yaml
+++ b/rust/benchmarks/tpch/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
   ballista-scheduler:
     image: ballistacompute/ballista-rust:0.4.0-SNAPSHOT
     command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --port 50050"
+    environment:
+      - RUST_LOG=debug
     ports:
       - "50050:50050"
     depends_on:
@@ -15,6 +17,8 @@ services:
   ballista-executor:
     image: ballistacompute/ballista-rust:0.4.0-SNAPSHOT
     command: "/executor --bind-host 0.0.0.0 --port 50051 --scheduler-host ballista-scheduler"
+    environment:
+      - RUST_LOG=debug
     ports:
       - "50051:50051"
     volumes:

--- a/rust/benchmarks/tpch/docker-compose.yaml
+++ b/rust/benchmarks/tpch/docker-compose.yaml
@@ -5,35 +5,25 @@ services:
     command: "etcd -advertise-client-urls http://etcd:2379 -listen-client-urls http://0.0.0.0:2379"
     ports:
       - "2379:2379"
-  ballista-scheduler:
-    image: ballistacompute/ballista-rust:0.4.0-SNAPSHOT
-    command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --port 50050"
-    environment:
-      - RUST_LOG=debug
-    ports:
-      - "50050:50050"
-    depends_on:
-      - etcd
+#  ballista-scheduler:
+#    image: ballistacompute/ballista-rust:0.4.0-SNAPSHOT
+#    command: "/scheduler --config-backend etcd --etcd-urls etcd:2379 --bind-host 0.0.0.0 --port 50050"
+#    environment:
+#      - RUST_LOG=debug
+#    ports:
+#      - "50050:50050"
+#    volumes:
+#      - ./data:/data
+#    depends_on:
+#      - etcd
   ballista-executor:
     image: ballistacompute/ballista-rust:0.4.0-SNAPSHOT
-    command: "/executor --bind-host 0.0.0.0 --port 50051 --scheduler-host ballista-scheduler"
+    command: "/executor --bind-host 0.0.0.0 --port 50051 --local"
     environment:
-      - RUST_LOG=debug
+      - RUST_LOG=info
     ports:
+      - "50050:50050"
       - "50051:50051"
     volumes:
       - ./data:/data
-    depends_on:
-      - ballista-scheduler
-#  ballista-jvm:
-#    image: ballistacompute/ballista-jvm:0.4.0-SNAPSHOT
-#    ports:
-#      - "50052:50051"
-#    volumes:
-#      - /mnt/nyctaxi:/mnt/nyctaxi
-#  ballista-spark:
-#    image: ballistacompute/ballista-spark:0.4.0-SNAPSHOT
-#    ports:
-#      - "50053:50051"
-#    volumes:
-#      - ./data:/mnt/tpch
+

--- a/rust/benchmarks/tpch/src/main.rs
+++ b/rust/benchmarks/tpch/src/main.rs
@@ -53,7 +53,7 @@ struct BenchmarkOpt {
     debug: bool,
 
     /// Number of iterations of each test run
-    #[structopt(long = "iterations", default_value = "3")]
+    #[structopt(long = "iterations", default_value = "1")]
     iterations: usize,
 
     /// Batch size when reading CSV or Parquet files


### PR DESCRIPTION
To run integration tests locally:

```bash
./dev/integration-tests.sh
```

Note that for now it is necessary to have write access to `/data` on the local file system until https://github.com/ballista-compute/ballista/issues/473 is resolved.