### PR TITLE
README TPC-H benchmark link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ in any programming language with minimal serialization overhead.
 
 The following examples should help illustrate the current capabilities of Ballista
 
-- [TPC-H Benchmark](https://github.com/ballista-compute/ballista/tree/main/benchmarks/tpch)
+- [TPC-H Benchmark](rust/benchmarks/tpch)
 
 ## Releases
 


### PR DESCRIPTION
The README's link to the TPC-H benchmarks is broken. Perhaps it went stale after Rust code was moved into the `rust/` subdirectory.

This updates the link. Additionally, it uses relative link syntax, which should be invariant to branch/commit.