### PR TITLE
Implement logical to_proto for ScalarFunction

### DIFF
--- a/rust/ballista/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/src/serde/logical_plan/mod.rs
@@ -23,6 +23,7 @@ mod roundtrip_tests {
     use crate::error::BallistaError;
     use arrow::datatypes::{DataType, Field, Schema};
     use core::panic;
+    use datafusion::physical_plan::functions::BuiltinScalarFunction::Sqrt;
     use datafusion::{
         logical_plan::{Expr, LogicalPlan, LogicalPlanBuilder},
         physical_plan::csv::CsvReadOptions,
@@ -31,7 +32,6 @@ mod roundtrip_tests {
     };
     use protobuf::arrow_type;
     use std::convert::TryInto;
-    use datafusion::physical_plan::functions::BuiltinScalarFunction::Sqrt;
 
     //Given a identity of a LogicalPlan converts it to protobuf and back, using debug formatting to test equality.
     macro_rules! roundtrip_test {
@@ -905,7 +905,7 @@ mod roundtrip_tests {
     fn roundtrip_sqrt() -> Result<()> {
         let test_expr = Expr::ScalarFunction {
             fun: Sqrt,
-            args: vec![col("col")]
+            args: vec![col("col")],
         };
         roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
 

--- a/rust/ballista/src/serde/logical_plan/mod.rs
+++ b/rust/ballista/src/serde/logical_plan/mod.rs
@@ -31,6 +31,7 @@ mod roundtrip_tests {
     };
     use protobuf::arrow_type;
     use std::convert::TryInto;
+    use datafusion::physical_plan::functions::BuiltinScalarFunction::Sqrt;
 
     //Given a identity of a LogicalPlan converts it to protobuf and back, using debug formatting to test equality.
     macro_rules! roundtrip_test {
@@ -895,6 +896,17 @@ mod roundtrip_tests {
     fn roundtrip_wildcard() -> Result<()> {
         let test_expr = Expr::Wildcard;
 
+        roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
+
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_sqrt() -> Result<()> {
+        let test_expr = Expr::ScalarFunction {
+            fun: Sqrt,
+            args: vec![col("col")]
+        };
         roundtrip_test!(test_expr, protobuf::LogicalExprNode, Expr);
 
         Ok(())

--- a/rust/ballista/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/to_proto.rs
@@ -997,10 +997,10 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
             Expr::ScalarVariable(_) => unimplemented!(),
             Expr::ScalarFunction { ref fun, ref args } => {
                 let fun: protobuf::ScalarFunction = fun.try_into()?;
-                let expr: Vec<protobuf::LogicalExprNode> = args
-                    .iter()
-                    .map(|e|Ok(e.try_into()?))
-                    .collect::<Result<Vec<protobuf::LogicalExprNode>, BallistaError>>()?;
+                let expr: Vec<protobuf::LogicalExprNode> =
+                    args.iter()
+                        .map(|e| Ok(e.try_into()?))
+                        .collect::<Result<Vec<protobuf::LogicalExprNode>, BallistaError>>()?;
                 Ok(protobuf::LogicalExprNode {
                     expr_type: Some(protobuf::logical_expr_node::ExprType::ScalarFunction(
                         protobuf::ScalarFunctionNode {
@@ -1009,7 +1009,7 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                         },
                     )),
                 })
-            },
+            }
             Expr::ScalarUDF { .. } => unimplemented!(),
             Expr::AggregateUDF { .. } => unimplemented!(),
             Expr::Not(expr) => {
@@ -1165,7 +1165,7 @@ impl TryFrom<&arrow::datatypes::DataType> for protobuf::ScalarType {
 impl TryInto<protobuf::ScalarFunction> for &BuiltinScalarFunction {
     type Error = BallistaError;
     fn try_into(self) -> Result<protobuf::ScalarFunction, Self::Error> {
-         match self {
+        match self {
             BuiltinScalarFunction::Sqrt => Ok(protobuf::ScalarFunction::Sqrt),
             BuiltinScalarFunction::Sin => Ok(protobuf::ScalarFunction::Sin),
             BuiltinScalarFunction::Cos => Ok(protobuf::ScalarFunction::Cos),
@@ -1204,4 +1204,3 @@ impl TryInto<protobuf::ScalarFunction> for &BuiltinScalarFunction {
         }
     }
 }
-

--- a/rust/ballista/src/serde/logical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/logical_plan/to_proto.rs
@@ -35,6 +35,7 @@ use protobuf::{
 };
 
 use super::super::proto_error;
+use datafusion::physical_plan::functions::BuiltinScalarFunction;
 
 impl protobuf::IntervalUnit {
     pub fn from_arrow_interval_unit(interval_unit: &arrow::datatypes::IntervalUnit) -> Self {
@@ -994,7 +995,21 @@ impl TryInto<protobuf::LogicalExprNode> for &Expr {
                 })
             }
             Expr::ScalarVariable(_) => unimplemented!(),
-            Expr::ScalarFunction { .. } => unimplemented!(),
+            Expr::ScalarFunction { ref fun, ref args } => {
+                let fun: protobuf::ScalarFunction = fun.try_into()?;
+                let expr: Vec<protobuf::LogicalExprNode> = args
+                    .iter()
+                    .map(|e|Ok(e.try_into()?))
+                    .collect::<Result<Vec<protobuf::LogicalExprNode>, BallistaError>>()?;
+                Ok(protobuf::LogicalExprNode {
+                    expr_type: Some(protobuf::logical_expr_node::ExprType::ScalarFunction(
+                        protobuf::ScalarFunctionNode {
+                            fun: fun.into(),
+                            expr,
+                        },
+                    )),
+                })
+            },
             Expr::ScalarUDF { .. } => unimplemented!(),
             Expr::AggregateUDF { .. } => unimplemented!(),
             Expr::Not(expr) => {
@@ -1146,3 +1161,47 @@ impl TryFrom<&arrow::datatypes::DataType> for protobuf::ScalarType {
         })
     }
 }
+
+impl TryInto<protobuf::ScalarFunction> for &BuiltinScalarFunction {
+    type Error = BallistaError;
+    fn try_into(self) -> Result<protobuf::ScalarFunction, Self::Error> {
+         match self {
+            BuiltinScalarFunction::Sqrt => Ok(protobuf::ScalarFunction::Sqrt),
+            BuiltinScalarFunction::Sin => Ok(protobuf::ScalarFunction::Sin),
+            BuiltinScalarFunction::Cos => Ok(protobuf::ScalarFunction::Cos),
+            BuiltinScalarFunction::Tan => Ok(protobuf::ScalarFunction::Tan),
+            BuiltinScalarFunction::Asin => Ok(protobuf::ScalarFunction::Asin),
+            BuiltinScalarFunction::Acos => Ok(protobuf::ScalarFunction::Acos),
+            BuiltinScalarFunction::Atan => Ok(protobuf::ScalarFunction::Atan),
+            BuiltinScalarFunction::Exp => Ok(protobuf::ScalarFunction::Exp),
+            BuiltinScalarFunction::Log => Ok(protobuf::ScalarFunction::Log),
+            BuiltinScalarFunction::Log10 => Ok(protobuf::ScalarFunction::Log10),
+            BuiltinScalarFunction::Floor => Ok(protobuf::ScalarFunction::Floor),
+            BuiltinScalarFunction::Ceil => Ok(protobuf::ScalarFunction::Ceil),
+            BuiltinScalarFunction::Round => Ok(protobuf::ScalarFunction::Round),
+            BuiltinScalarFunction::Trunc => Ok(protobuf::ScalarFunction::Trunc),
+            BuiltinScalarFunction::Abs => Ok(protobuf::ScalarFunction::Abs),
+            BuiltinScalarFunction::Length => Ok(protobuf::ScalarFunction::Length),
+            BuiltinScalarFunction::Concat => Ok(protobuf::ScalarFunction::Concat),
+            BuiltinScalarFunction::Lower => Ok(protobuf::ScalarFunction::Lower),
+            BuiltinScalarFunction::Upper => Ok(protobuf::ScalarFunction::Upper),
+            BuiltinScalarFunction::Trim => Ok(protobuf::ScalarFunction::Trim),
+            BuiltinScalarFunction::Ltrim => Ok(protobuf::ScalarFunction::Ltrim),
+            BuiltinScalarFunction::Rtrim => Ok(protobuf::ScalarFunction::Rtrim),
+            BuiltinScalarFunction::ToTimestamp => Ok(protobuf::ScalarFunction::Totimestamp),
+            BuiltinScalarFunction::Array => Ok(protobuf::ScalarFunction::Array),
+            BuiltinScalarFunction::NullIf => Ok(protobuf::ScalarFunction::Nullif),
+            BuiltinScalarFunction::DateTrunc => Ok(protobuf::ScalarFunction::Datetrunc),
+            BuiltinScalarFunction::MD5 => Ok(protobuf::ScalarFunction::Md5),
+            BuiltinScalarFunction::SHA224 => Ok(protobuf::ScalarFunction::Sha224),
+            BuiltinScalarFunction::SHA256 => Ok(protobuf::ScalarFunction::Sha256),
+            BuiltinScalarFunction::SHA384 => Ok(protobuf::ScalarFunction::Sha384),
+            BuiltinScalarFunction::SHA512 => Ok(protobuf::ScalarFunction::Sha512),
+            _ => Err(BallistaError::General(format!(
+                "logical_plan::to_proto() unsupported scalar function {:?}",
+                self
+            ))),
+        }
+    }
+}
+

--- a/rust/ballista/src/serde/physical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/physical_plan/to_proto.rs
@@ -54,7 +54,7 @@ use protobuf::physical_plan_node::PhysicalPlanType;
 
 use crate::executor::shuffle_reader::ShuffleReaderExec;
 use crate::serde::{protobuf, BallistaError};
-use datafusion::physical_plan::functions::{ScalarFunctionExpr, BuiltinScalarFunction};
+use datafusion::physical_plan::functions::{BuiltinScalarFunction, ScalarFunctionExpr};
 use datafusion::physical_plan::merge::MergeExec;
 
 impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
@@ -435,7 +435,7 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::LogicalExprNode {
                 ))),
             })
         } else if let Some(expr) = expr.downcast_ref::<ScalarFunctionExpr>() {
-            let fun: BuiltinScalarFunction= BuiltinScalarFunction::from_str(expr.name())?;
+            let fun: BuiltinScalarFunction = BuiltinScalarFunction::from_str(expr.name())?;
             let fun: protobuf::ScalarFunction = (&fun).try_into()?;
             let expr: Vec<protobuf::LogicalExprNode> = expr
                 .args()

--- a/rust/ballista/src/serde/physical_plan/to_proto.rs
+++ b/rust/ballista/src/serde/physical_plan/to_proto.rs
@@ -18,6 +18,7 @@
 
 use std::{
     convert::{TryFrom, TryInto},
+    str::FromStr,
     sync::Arc,
 };
 
@@ -53,7 +54,7 @@ use protobuf::physical_plan_node::PhysicalPlanType;
 
 use crate::executor::shuffle_reader::ShuffleReaderExec;
 use crate::serde::{protobuf, BallistaError};
-use datafusion::physical_plan::functions::ScalarFunctionExpr;
+use datafusion::physical_plan::functions::{ScalarFunctionExpr, BuiltinScalarFunction};
 use datafusion::physical_plan::merge::MergeExec;
 
 impl TryInto<protobuf::PhysicalPlanNode> for Arc<dyn ExecutionPlan> {
@@ -434,43 +435,8 @@ impl TryFrom<Arc<dyn PhysicalExpr>> for protobuf::LogicalExprNode {
                 ))),
             })
         } else if let Some(expr) = expr.downcast_ref::<ScalarFunctionExpr>() {
-            let fun = match expr.name() {
-                "sqrt" => Ok(protobuf::ScalarFunction::Sqrt),
-                "sin" => Ok(protobuf::ScalarFunction::Sin),
-                "cos" => Ok(protobuf::ScalarFunction::Cos),
-                "tan" => Ok(protobuf::ScalarFunction::Tan),
-                "asin" => Ok(protobuf::ScalarFunction::Asin),
-                "acos" => Ok(protobuf::ScalarFunction::Acos),
-                "atan" => Ok(protobuf::ScalarFunction::Atan),
-                "exp" => Ok(protobuf::ScalarFunction::Exp),
-                "log" => Ok(protobuf::ScalarFunction::Log),
-                "log10" => Ok(protobuf::ScalarFunction::Log10),
-                "floor" => Ok(protobuf::ScalarFunction::Floor),
-                "ceil" => Ok(protobuf::ScalarFunction::Ceil),
-                "round" => Ok(protobuf::ScalarFunction::Round),
-                "trunc" => Ok(protobuf::ScalarFunction::Trunc),
-                "abs" => Ok(protobuf::ScalarFunction::Abs),
-                "length" => Ok(protobuf::ScalarFunction::Length),
-                "concat" => Ok(protobuf::ScalarFunction::Concat),
-                "lower" => Ok(protobuf::ScalarFunction::Lower),
-                "upper" => Ok(protobuf::ScalarFunction::Upper),
-                "trim" => Ok(protobuf::ScalarFunction::Trim),
-                "ltrim" => Ok(protobuf::ScalarFunction::Ltrim),
-                "rtrim" => Ok(protobuf::ScalarFunction::Rtrim),
-                "totimestamp" => Ok(protobuf::ScalarFunction::Totimestamp),
-                "array" => Ok(protobuf::ScalarFunction::Array),
-                "nullif" => Ok(protobuf::ScalarFunction::Nullif),
-                "datetrunc" => Ok(protobuf::ScalarFunction::Datetrunc),
-                "md5" => Ok(protobuf::ScalarFunction::Md5),
-                "sha224" => Ok(protobuf::ScalarFunction::Sha224),
-                "sha256" => Ok(protobuf::ScalarFunction::Sha256),
-                "sha384" => Ok(protobuf::ScalarFunction::Sha384),
-                "sha512" => Ok(protobuf::ScalarFunction::Sha512),
-                _ => Err(BallistaError::General(format!(
-                    "physical_plan::to_proto() unsupported scalar function {:?}",
-                    expr
-                ))),
-            }?;
+            let fun: BuiltinScalarFunction= BuiltinScalarFunction::from_str(expr.name())?;
+            let fun: protobuf::ScalarFunction = (&fun).try_into()?;
             let expr: Vec<protobuf::LogicalExprNode> = expr
                 .args()
                 .iter()


### PR DESCRIPTION
Addresses #518.

Refactors matching logic into `TryInto<protobuf::ScalarFunction> for &BuiltinScalarFunction` and uses this in both logical and physical serialization of scalar functions.

Adds a roundtrip test for `sqrt` to check implementation.

_Note: Couldn't run integration test on Mac OSX, will have to finish #473 for that._