### PR TITLE
Refactor in preparation for streaming

### DIFF
--- a/rust/ballista/src/client.rs
+++ b/rust/ballista/src/client.rs
@@ -61,18 +61,6 @@ impl BallistaClient {
         Ok(Self { flight_client })
     }
 
-    /// Execute a logical query plan and retrieve the results
-    pub async fn execute_query(&mut self, plan: &LogicalPlan) -> Result<SendableRecordBatchStream> {
-        let action = Action::InteractiveQuery {
-            plan: plan.to_owned(),
-            settings: HashMap::new(),
-        };
-
-        self.execute_action(&action).await
-
-        //Ok(Arc::new(CollectExec::new(final_stage)))
-    }
-
     /// Execute one partition of a physical query plan against the executor
     pub async fn execute_partition(
         &mut self,

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -17,6 +17,7 @@
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Instant;
 
 use crate::executor::BallistaExecutor;
@@ -25,9 +26,12 @@ use crate::serde::decode_protobuf;
 use crate::serde::scheduler::Action as BallistaAction;
 use crate::utils;
 
+use crate::error::BallistaError;
+use crate::memory_stream::MemoryStream;
 use arrow::array::{ArrayRef, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::ArrowError;
+use arrow::ipc::writer::IpcWriteOptions;
 use arrow::record_batch::RecordBatch;
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty, FlightData,
@@ -35,6 +39,7 @@ use arrow_flight::{
     Ticket,
 };
 use datafusion::error::DataFusionError;
+use datafusion::physical_plan::RecordBatchStream;
 use futures::{Stream, StreamExt};
 use log::{debug, info};
 use tonic::{Request, Response, Status, Streaming};
@@ -75,27 +80,6 @@ impl FlightService for BallistaFlightService {
         let action = decode_protobuf(&ticket.ticket).map_err(|e| from_ballista_err(&e))?;
 
         match &action {
-            BallistaAction::InteractiveQuery { plan, .. } => {
-                info!("InteractiveQuery {:?}", plan);
-
-                let results = self
-                    .executor
-                    .execute_logical_plan(&plan)
-                    .await
-                    .map_err(|e| from_ballista_err(&e))?;
-
-                if results.is_empty() {
-                    return Err(Status::internal("There were no results from ticket"));
-                }
-                debug!("Received {} record batches", results.len());
-
-                let df_schema = plan.schema();
-                let arrow_schema: Schema = df_schema.clone().as_ref().clone().into();
-
-                let flights = create_flight_data(Arc::new(arrow_schema), results);
-                let output = futures::stream::iter(flights);
-                Ok(Response::new(Box::pin(output) as Self::DoGetStream))
-            }
             BallistaAction::ExecutePartition(partition) => {
                 info!("ExecutePartition {:?}", partition);
                 pretty_print(partition.plan.clone(), 0);
@@ -138,7 +122,20 @@ impl FlightService for BallistaFlightService {
                 let schema = Arc::new(Schema::new(vec![Field::new("path", DataType::Utf8, false)]));
 
                 let results = vec![RecordBatch::try_new(schema.clone(), vec![path]).unwrap()];
-                let flights = create_flight_data(schema, results);
+                // add an initial FlightData message that sends schema
+                let options = arrow::ipc::writer::IpcWriteOptions::default();
+                let schema_flight_data =
+                    arrow_flight::utils::flight_data_from_arrow_schema(schema.as_ref(), &options);
+
+                let mut flights: Vec<Result<FlightData, Status>> = vec![Ok(schema_flight_data)];
+
+                let mut batches: Vec<Result<FlightData, Status>> = results
+                    .iter()
+                    .flat_map(|batch| create_flight_iter(batch, &options))
+                    .collect();
+
+                // append batch vector to schema vector, so that the first message sent is the schema
+                flights.append(&mut batches);
                 let output = futures::stream::iter(flights);
 
                 Ok(Response::new(Box::pin(output) as Self::DoGetStream))
@@ -165,7 +162,22 @@ impl FlightService for BallistaFlightService {
                     batches.push(batch.map_err(|e| from_arrow_err(&e))?);
                 }
 
-                let flights = create_flight_data(stream.schema(), batches);
+                // add an initial FlightData message that sends schema
+                let options = arrow::ipc::writer::IpcWriteOptions::default();
+                let schema_flight_data = arrow_flight::utils::flight_data_from_arrow_schema(
+                    stream.schema().as_ref(),
+                    &options,
+                );
+
+                let mut flights: Vec<Result<FlightData, Status>> = vec![Ok(schema_flight_data)];
+
+                let mut batches: Vec<Result<FlightData, Status>> = batches
+                    .iter()
+                    .flat_map(|batch| create_flight_iter(batch, &options))
+                    .collect();
+
+                // append batch vector to schema vector, so that the first message sent is the schema
+                flights.append(&mut batches);
                 let output = futures::stream::iter(flights);
 
                 Ok(Response::new(Box::pin(output) as Self::DoGetStream))
@@ -240,34 +252,20 @@ impl FlightService for BallistaFlightService {
     }
 }
 
-/// Convert a result set into flight data
-fn create_flight_data(
-    schema: SchemaRef,
-    results: Vec<RecordBatch>,
-) -> Vec<Result<FlightData, Status>> {
-    // add an initial FlightData message that sends schema
-    let options = arrow::ipc::writer::IpcWriteOptions::default();
-    let schema_flight_data =
-        arrow_flight::utils::flight_data_from_arrow_schema(schema.as_ref(), &options);
-
-    let mut flights: Vec<Result<FlightData, Status>> = vec![Ok(schema_flight_data)];
-
-    let mut batches: Vec<Result<FlightData, Status>> = results
-        .iter()
-        .flat_map(|batch| {
-            let (flight_dictionaries, flight_batch) =
-                arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
-            flight_dictionaries
-                .into_iter()
-                .chain(std::iter::once(flight_batch))
-                .map(Ok)
-        })
-        .collect();
-
-    // append batch vector to schema vector, so that the first message sent is the schema
-    flights.append(&mut batches);
-
-    flights
+/// Convert a single RecordBatch into an iterator of FlightData (containing
+/// dictionaries and batches)
+fn create_flight_iter(
+    batch: &RecordBatch,
+    options: &IpcWriteOptions,
+) -> Box<dyn Iterator<Item = Result<FlightData, Status>>> {
+    let (flight_dictionaries, flight_batch) =
+        arrow_flight::utils::flight_data_from_arrow_batch(batch, &options);
+    Box::new(
+        flight_dictionaries
+            .into_iter()
+            .chain(std::iter::once(flight_batch))
+            .map(Ok),
+    )
 }
 
 fn from_arrow_err(e: &ArrowError) -> Status {

--- a/rust/ballista/src/serde/scheduler/from_proto.rs
+++ b/rust/ballista/src/serde/scheduler/from_proto.rs
@@ -28,17 +28,6 @@ impl TryInto<Action> for protobuf::Action {
 
     fn try_into(self) -> Result<Action, Self::Error> {
         match self.action_type {
-            Some(ActionType::Query(query)) => {
-                let mut settings = HashMap::new();
-                let plan: LogicalPlan = (&query).try_into()?;
-                for setting in &self.settings {
-                    settings.insert(setting.key.to_owned(), setting.value.to_owned());
-                    for setting in &self.settings {
-                        settings.insert(setting.key.to_owned(), setting.value.to_owned());
-                    }
-                }
-                Ok(Action::InteractiveQuery { plan, settings })
-            }
             Some(ActionType::ExecutePartition(partition)) => {
                 // TODO remove unwraps
                 Ok(Action::ExecutePartition(ExecutePartition::new(

--- a/rust/ballista/src/serde/scheduler/mod.rs
+++ b/rust/ballista/src/serde/scheduler/mod.rs
@@ -28,14 +28,6 @@ pub mod to_proto;
 #[derive(Debug, Clone)]
 
 pub enum Action {
-    /// Execute the query and return the results
-    InteractiveQuery {
-        /// Logical plan to execute
-        plan: LogicalPlan,
-        /// Settings that can be used to control certain aspects of query execution, such as
-        /// batch sizes
-        settings: HashMap<String, String>,
-    },
     /// Execute a query and store the results in memory
     ExecutePartition(ExecutePartition),
     /// Collect a shuffle partition

--- a/rust/ballista/src/serde/scheduler/to_proto.rs
+++ b/rust/ballista/src/serde/scheduler/to_proto.rs
@@ -25,23 +25,6 @@ impl TryInto<protobuf::Action> for Action {
 
     fn try_into(self) -> Result<protobuf::Action, Self::Error> {
         match self {
-            Action::InteractiveQuery {
-                ref plan,
-                ref settings,
-            } => {
-                let settings = settings
-                    .iter()
-                    .map(|e| protobuf::KeyValuePair {
-                        key: e.0.to_string(),
-                        value: e.1.to_string(),
-                    })
-                    .collect();
-
-                Ok(protobuf::Action {
-                    action_type: Some(ActionType::Query(plan.try_into()?)),
-                    settings,
-                })
-            }
             Action::ExecutePartition(partition) => Ok(protobuf::Action {
                 action_type: Some(ActionType::ExecutePartition(partition.try_into()?)),
                 settings: vec![],

--- a/rust/ballista/src/utils.rs
+++ b/rust/ballista/src/utils.rs
@@ -75,25 +75,6 @@ pub async fn write_stream_to_disk(
     })
 }
 
-pub async fn read_stream_from_disk(
-    path: &str,
-) -> Result<Pin<Box<dyn RecordBatchStream + Send + Sync>>> {
-    let file = File::open(&path).map_err(|e| {
-        BallistaError::General(format!(
-            "Failed to open partition file at {}: {:?}",
-            path, e
-        ))
-    })?;
-    let reader = FileReader::try_new(file)?;
-    let schema = reader.schema();
-    // TODO we should be able return a stream / iterator rather than load into memory first
-    let mut batches = vec![];
-    for batch in reader {
-        batches.push(batch?);
-    }
-    Ok(Box::pin(MemoryStream::try_new(batches, schema, None)?))
-}
-
 pub async fn collect_stream(
     stream: &mut Pin<Box<dyn RecordBatchStream + Send + Sync>>,
 ) -> Result<Vec<RecordBatch>> {


### PR DESCRIPTION
This reduces memory overhead a bit by avoiding copying all the batches into a vec twice - now it only does it once. Still not great.

Also:
- Refactors the code in preparation for streaming
- Removes the legacy code for executors executing queries in-process with DataFusion