### PR TITLE
Improve debug formatting of physical plans

### DIFF
--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -21,10 +21,9 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use crate::executor::BallistaExecutor;
-use crate::scheduler::planner::pretty_print;
 use crate::serde::decode_protobuf;
 use crate::serde::scheduler::Action as BallistaAction;
-use crate::utils;
+use crate::utils::{self, format_plan};
 
 use crate::error::BallistaError;
 use crate::memory_stream::MemoryStream;
@@ -83,8 +82,13 @@ impl FlightService for BallistaFlightService {
 
         match &action {
             BallistaAction::ExecutePartition(partition) => {
-                info!("ExecutePartition {:?}", partition);
-                pretty_print(partition.plan.clone(), 0);
+                info!(
+                    "ExecutePartition: job={}, stage={}, partition={}\n{}",
+                    partition.job_uuid,
+                    partition.stage_id,
+                    partition.partition_id,
+                    format_plan(partition.plan.clone(), 0)
+                );
 
                 let mut path = PathBuf::from(&self.executor.config.work_dir);
                 path.push(&format!("{}", partition.job_uuid));

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -87,7 +87,7 @@ impl FlightService for BallistaFlightService {
                     partition.job_uuid,
                     partition.stage_id,
                     partition.partition_id,
-                    format_plan(partition.plan.clone(), 0)
+                    format_plan(partition.plan.clone(), 0).map_err(|e| from_ballista_err(&e))?
                 );
 
                 let mut path = PathBuf::from(&self.executor.config.work_dir);

--- a/rust/ballista/src/scheduler/planner.rs
+++ b/rust/ballista/src/scheduler/planner.rs
@@ -29,14 +29,19 @@ use crate::serde::scheduler::ExecutorMeta;
 use crate::serde::scheduler::PartitionId;
 use crate::utils;
 
+use crate::utils::format_plan;
 use arrow::record_batch::RecordBatch;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::ExecutionContext;
 use datafusion::logical_plan::LogicalPlan;
+use datafusion::physical_plan::csv::CsvExec;
+use datafusion::physical_plan::expressions::Column;
 use datafusion::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
 use datafusion::physical_plan::hash_join::HashJoinExec;
 use datafusion::physical_plan::merge::MergeExec;
-use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
+use datafusion::physical_plan::{
+    AggregateExpr, ExecutionPlan, PhysicalExpr, SendableRecordBatchStream,
+};
 use log::{debug, info};
 use uuid::Uuid;
 
@@ -97,7 +102,7 @@ impl DistributedPlanner {
         let execution_plans = self.plan_query_stages(&job_uuid, execution_plan)?;
 
         for plan in &execution_plans {
-            pretty_print(plan.clone(), 0);
+            println!("{}", format_plan(plan.clone(), 0));
         }
 
         execute(execution_plans, self.executors.clone()).await
@@ -275,8 +280,11 @@ async fn execute_query_stage(
     plan: Arc<dyn ExecutionPlan>,
     executors: Vec<ExecutorMeta>,
 ) -> Result<Vec<PartitionLocation>> {
-    info!("execute_query_stage() stage_id={}", stage_id);
-    pretty_print(plan.clone(), 0);
+    info!(
+        "execute_query_stage() stage_id={}\n{}",
+        stage_id,
+        format_plan(plan.clone(), 0)
+    );
 
     let _job_uuid = *job_uuid;
     let partition_count = plan.output_partitioning().partition_count();
@@ -333,22 +341,15 @@ async fn execute_query_stage(
     Ok(meta)
 }
 
-pub fn pretty_print(plan: Arc<dyn ExecutionPlan>, indent: usize) {
-    let operator_str = format!("{:?}", plan);
-    debug!("{}{:?}", "  ".repeat(indent), &operator_str[0..60]);
-    plan.children()
-        .iter()
-        .for_each(|c| pretty_print(c.clone(), indent + 1));
-}
-
 #[cfg(test)]
 mod test {
     use crate::scheduler::execution_plans::QueryStageExec;
-    use crate::scheduler::planner::{pretty_print, DistributedPlanner};
+    use crate::scheduler::planner::DistributedPlanner;
     use crate::serde::protobuf;
     use crate::serde::scheduler::ExecutorMeta;
     use crate::test_utils;
     use crate::test_utils::{datafusion_test_context, TPCH_TABLES};
+    use crate::utils::format_plan;
     use crate::{error::BallistaError, scheduler::execution_plans::UnresolvedShuffleExec};
     use arrow::datatypes::DataType;
     use datafusion::execution::context::ExecutionContext;

--- a/rust/ballista/src/scheduler/planner.rs
+++ b/rust/ballista/src/scheduler/planner.rs
@@ -102,7 +102,7 @@ impl DistributedPlanner {
         let execution_plans = self.plan_query_stages(&job_uuid, execution_plan)?;
 
         for plan in &execution_plans {
-            println!("{}", format_plan(plan.clone(), 0));
+            println!("{}", format_plan(plan.clone(), 0)?);
         }
 
         execute(execution_plans, self.executors.clone()).await
@@ -283,7 +283,7 @@ async fn execute_query_stage(
     info!(
         "execute_query_stage() stage_id={}\n{}",
         stage_id,
-        format_plan(plan.clone(), 0)
+        format_plan(plan.clone(), 0)?
     );
 
     let _job_uuid = *job_uuid;

--- a/rust/ballista/src/utils.rs
+++ b/rust/ballista/src/utils.rs
@@ -12,15 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::{fs::File, pin::Pin};
 
 use crate::error::{BallistaError, Result};
 use crate::memory_stream::MemoryStream;
 
+use crate::scheduler::execution_plans::QueryStageExec;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
 use arrow::record_batch::RecordBatch;
-use datafusion::physical_plan::RecordBatchStream;
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::csv::CsvExec;
+use datafusion::physical_plan::expressions::{BinaryExpr, Column, Literal};
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::hash_aggregate::HashAggregateExec;
+use datafusion::physical_plan::merge::MergeExec;
+use datafusion::physical_plan::parquet::ParquetExec;
+use datafusion::physical_plan::{AggregateExpr, ExecutionPlan, PhysicalExpr, RecordBatchStream};
 use futures::StreamExt;
 
 /// Summary of executed partition
@@ -83,4 +92,74 @@ pub async fn collect_stream(
         batches.push(batch?);
     }
     Ok(batches)
+}
+
+pub fn format_plan(plan: Arc<dyn ExecutionPlan>, indent: usize) -> String {
+    let operator_str = if let Some(exec) = plan.as_any().downcast_ref::<HashAggregateExec>() {
+        format!(
+            "HashAggregateExec: groupBy={:?}, aggrExpr={:?}",
+            exec.group_expr()
+                .iter()
+                .map(|e| format_expr(e.0.as_ref()))
+                .collect::<Vec<String>>(),
+            exec.aggr_expr()
+                .iter()
+                .map(|e| format_agg_expr(e.as_ref()))
+                .collect::<Result<Vec<String>>>()
+        )
+    } else if let Some(exec) = plan.as_any().downcast_ref::<ParquetExec>() {
+        format!("ParquetExec: partitions={}", exec.partitions().len())
+    } else if let Some(exec) = plan.as_any().downcast_ref::<CsvExec>() {
+        format!("CsvExec: {}", &exec.path())
+    } else if let Some(exec) = plan.as_any().downcast_ref::<FilterExec>() {
+        format!("FilterExec: {}", format_expr(exec.predicate().as_ref()))
+    } else if let Some(exec) = plan.as_any().downcast_ref::<QueryStageExec>() {
+        format!(
+            "QueryStageExec: job={}, stage={}",
+            exec.job_uuid, exec.stage_id
+        )
+    } else if let Some(exec) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        format!(
+            "CoalesceBatchesExec: batchSize={}",
+            exec.target_batch_size()
+        )
+    } else if plan.as_any().downcast_ref::<MergeExec>().is_some() {
+        "MergeExec".to_string()
+    } else {
+        let str = format!("{:?}", plan);
+        String::from(&str[0..120])
+    };
+    format!(
+        "{}{}\n{}",
+        "  ".repeat(indent),
+        &operator_str,
+        plan.children()
+            .iter()
+            .map(|c| format_plan(c.clone(), indent + 1))
+            .collect::<Vec<String>>()
+            .join("\n")
+    )
+}
+
+pub fn format_agg_expr(expr: &dyn AggregateExpr) -> Result<String> {
+    Ok(format!(
+        "{} {:?}",
+        expr.field()?.name(),
+        expr.expressions()
+            .iter()
+            .map(|e| format_expr(e.as_ref()))
+            .collect::<Vec<String>>()
+    ))
+}
+
+pub fn format_expr(expr: &dyn PhysicalExpr) -> String {
+    if let Some(e) = expr.as_any().downcast_ref::<Column>() {
+        e.name().to_string()
+    } else if let Some(e) = expr.as_any().downcast_ref::<Literal>() {
+        e.to_string()
+    } else if let Some(e) = expr.as_any().downcast_ref::<BinaryExpr>() {
+        format!("{} {} {}", e.left(), e.op(), e.right())
+    } else {
+        format!("{}", expr)
+    }
 }


### PR DESCRIPTION
This is  a bit more concise now:

```
[2021-02-15T19:09:25Z INFO  ballista::scheduler::planner] execute_query_stage() stage_id=2
    MergeExec
      QueryStageExec: job=411e79af-8b0c-4705-9e39-c14452b8c7ed, stage=1
        HashAggregateExec: groupBy=["l_returnflag", "l_linestatus"], aggrExpr=["SUM(l_quantity) [\"l_quantity\"]", "SUM(l_extendedprice) [\"l_extendedprice\"]", "SUM(l_extendedprice Multiply Int64(1) Minus l_discount) [\"l_extendedprice * CAST(1 AS Float64) - l_discount\"]", "SUM(l_extendedprice Multiply Int64(1) Minus l_discount Multiply Int64(1) Plus l_tax) [\"l_extendedprice * CAST(1 AS Float64) - l_discount * CAST(1 AS Float64) + l_tax\"]", "AVG(l_quantity) [\"l_quantity\"]", "AVG(l_extendedprice) [\"l_extendedprice\"]", "AVG(l_discount) [\"l_discount\"]", "COUNT(UInt8(1)) [\"1\"]"]
          CoalesceBatchesExec: batchSize=16384
            FilterExec: l_shipdate <= CAST(1998-09-02 AS Date32)
              ParquetExec: partitions=8
```