### PR TITLE
Add snmalloc feature to docker image

### DIFF
--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -26,8 +26,10 @@ COPY rust/ballista/build.rs /tmp/ballista/
 RUN true
 COPY rust/ballista/src/ /tmp/ballista/src/
 # force build.rs to run to generate configure_me code.
+RUN apt-get -y install cmake
 ENV FORCE_REBUILD='true'
-RUN cargo build $RELEASE_FLAG
+ARG BUILD_FEATURES='--features snmalloc'
+RUN cargo build $RELEASE_FLAG $BUILD_FEATURES 
 
 # put the executor on /executor (need to be copied from different places depending on FLAG)
 ENV RELEASE_FLAG=${RELEASE_FLAG}


### PR DESCRIPTION
This enables the snmalloc feature, addressesing a part of https://github.com/ballista-compute/ballista/issues/549
enabling simd would require a nightly rust. 

I couldn't yet figure out how to do lto, as it is not directly building a binary with the current setup. "error: lto can only be run for executables, cdylibs and static library outputs". I think we only want to have lto enabled on the executor.