### PR TITLE
first pass at returning partition stats to scheduler

### DIFF
--- a/rust/ballista/src/client.rs
+++ b/rust/ballista/src/client.rs
@@ -23,6 +23,7 @@ use crate::memory_stream::MemoryStream;
 use crate::serde::protobuf::{self};
 use crate::serde::scheduler::{Action, ExecutePartition, ExecutePartitionResult, PartitionId};
 
+use crate::utils::PartitionStats;
 use arrow::array::{StringArray, StructArray};
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
@@ -35,7 +36,6 @@ use datafusion::{logical_plan::LogicalPlan, physical_plan::RecordBatchStream};
 use log::debug;
 use prost::Message;
 use uuid::Uuid;
-use crate::utils::PartitionStats;
 
 /// Client for interacting with Ballista executors.
 pub struct BallistaClient {
@@ -105,7 +105,10 @@ impl BallistaClient {
             .downcast_ref::<StructArray>()
             .expect("execute_partition expected column 1 to be a StructArray");
 
-        Ok(ExecutePartitionResult::new(path.value(0), PartitionStats::from_arrow_struct_array(stats)))
+        Ok(ExecutePartitionResult::new(
+            path.value(0),
+            PartitionStats::from_arrow_struct_array(stats),
+        ))
     }
 
     /// Fetch a partition from an executor

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -136,6 +136,8 @@ impl FlightService for BallistaFlightService {
                     info.arrow_struct_repr(),
                 ]));
                 let stats: ArrayRef = info.to_arrow_arrayref();
+                info!("stats len {}", stats.len());
+                info!("[ath] len {}", path.len());
 
                 let results =
                     vec![RecordBatch::try_new(schema.clone(), vec![path, stats]).unwrap()];

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -26,7 +26,7 @@ use crate::executor::BallistaExecutor;
 use crate::memory_stream::MemoryStream;
 use crate::serde::decode_protobuf;
 use crate::serde::scheduler::Action as BallistaAction;
-use crate::utils::{self, format_plan};
+use crate::utils::{self, format_plan, PartitionStats};
 
 use arrow::array::{ArrayRef, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -44,6 +44,7 @@ use datafusion::error::DataFusionError;
 use datafusion::physical_plan::RecordBatchStream;
 use futures::{Stream, StreamExt};
 use log::{debug, info, warn};
+use std::collections::HashMap;
 use std::io::{Read, Seek};
 use tokio::task;
 use tonic::{Request, Response, Status, Streaming};
@@ -130,9 +131,14 @@ impl FlightService for BallistaFlightService {
                 c0.append_value(&path).unwrap();
                 let path: ArrayRef = Arc::new(c0.finish());
 
-                let schema = Arc::new(Schema::new(vec![Field::new("path", DataType::Utf8, false)]));
+                let schema = Arc::new(Schema::new(vec![
+                    Field::new("path", DataType::Utf8, false),
+                    info.arrow_struct_repr(),
+                ]));
+                let stats: ArrayRef = info.to_arrow_arrayref();
 
-                let results = vec![RecordBatch::try_new(schema.clone(), vec![path]).unwrap()];
+                let results =
+                    vec![RecordBatch::try_new(schema.clone(), vec![path, stats]).unwrap()];
                 // add an initial FlightData message that sends schema
                 let options = arrow::ipc::writer::IpcWriteOptions::default();
                 let schema_flight_data =

--- a/rust/ballista/src/scheduler/planner.rs
+++ b/rust/ballista/src/scheduler/planner.rs
@@ -112,6 +112,7 @@ impl DistributedPlanner {
         job_uuid: &Uuid,
         execution_plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Vec<Arc<QueryStageExec>>> {
+        info!("planning query stages");
         let (new_plan, mut stages) = self.plan_query_stages_internal(job_uuid, execution_plan)?;
         stages.push(create_query_stage(
             job_uuid,

--- a/rust/ballista/src/serde/scheduler/mod.rs
+++ b/rust/ballista/src/serde/scheduler/mod.rs
@@ -20,6 +20,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use uuid::Uuid;
 
 use super::protobuf;
+use crate::utils::PartitionStats;
 
 pub mod from_proto;
 pub mod to_proto;
@@ -123,12 +124,14 @@ impl ExecutePartition {
 pub struct ExecutePartitionResult {
     /// Path containing results for this partition
     path: String,
+    stats: PartitionStats,
 }
 
 impl ExecutePartitionResult {
-    pub fn new(path: &str) -> Self {
+    pub fn new(path: &str, stats: PartitionStats) -> Self {
         Self {
             path: path.to_owned(),
+            stats: stats
         }
     }
 

--- a/rust/ballista/src/serde/scheduler/mod.rs
+++ b/rust/ballista/src/serde/scheduler/mod.rs
@@ -131,7 +131,7 @@ impl ExecutePartitionResult {
     pub fn new(path: &str, stats: PartitionStats) -> Self {
         Self {
             path: path.to_owned(),
-            stats: stats
+            stats,
         }
     }
 

--- a/rust/ballista/src/utils.rs
+++ b/rust/ballista/src/utils.rs
@@ -19,6 +19,10 @@ use crate::error::{BallistaError, Result};
 use crate::memory_stream::MemoryStream;
 
 use crate::scheduler::execution_plans::{QueryStageExec, UnresolvedShuffleExec};
+use arrow::array::{
+    ArrayBuilder, ArrayRef, StructArray, StructBuilder, UInt64Array, UInt64Builder,
+};
+use arrow::datatypes::{DataType, Field};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
 use arrow::record_batch::RecordBatch;
@@ -33,14 +37,109 @@ use datafusion::physical_plan::merge::MergeExec;
 use datafusion::physical_plan::parquet::ParquetExec;
 use datafusion::physical_plan::{AggregateExpr, ExecutionPlan, PhysicalExpr, RecordBatchStream};
 use futures::StreamExt;
+use std::collections::HashMap;
+use std::ops::Deref;
 
 /// Summary of executed partition
 #[derive(Debug, Copy, Clone)]
 pub struct PartitionStats {
-    num_rows: usize,
-    num_batches: usize,
-    num_bytes: usize,
-    null_count: usize,
+    num_rows: u64,
+    num_batches: u64,
+    num_bytes: u64,
+    null_count: u64,
+}
+
+impl PartitionStats {
+    // pub fn to_hash_map(&self) -> HashMap<String, String>{
+    //     let mut metadata: HashMap<String, String> = HashMap::new();
+    //     metadata.insert("num_rows".to_string(), self.num_rows.to_string());
+    //     metadata.insert("num_batches".to_string(), self.num_batches.to_string());
+    //     metadata.insert("num_bytes".to_string(), self.num_bytes.to_string());
+    //     metadata.insert("null_count".to_string(), self.null_count.to_string());
+    //     return metadata
+    // }
+    //
+    // pub fn from_hash_map(map: &HashMap<String, String>) -> Result<Self>{
+    //     return Ok(PartitionStats {
+    //         num_rows: map.get("num_rows")?.parse()?,
+    //         num_batches: map.get("num_batches")?.parse()?,
+    //         num_bytes: map.get("num_bytes")?.parse()?,
+    //         null_count: map.get("null_count")?.parse()?,
+    //     })
+    // }
+
+    pub fn arrow_struct_repr(self) -> Field {
+        Field::new(
+            "partition_stats",
+            DataType::Struct(vec![
+                Field::new("num_rows", DataType::UInt64, false),
+                Field::new("num_batches", DataType::UInt64, false),
+                Field::new("num_bytes", DataType::UInt64, false),
+                Field::new("null_count", DataType::UInt64, false),
+            ]),
+            false,
+        )
+    }
+
+    pub fn to_arrow_arrayref(&self) -> Arc<StructArray> {
+        let mut field_builders = Vec::new();
+
+        let mut num_rows_builder = UInt64Builder::new(1);
+        num_rows_builder.append_value(self.num_rows).unwrap();
+        field_builders.push(Box::new(num_rows_builder) as Box<dyn ArrayBuilder>);
+
+        let mut num_batches_builder = UInt64Builder::new(1);
+        num_batches_builder.append_value(self.num_batches).unwrap();
+        field_builders.push(Box::new(num_batches_builder) as Box<dyn ArrayBuilder>);
+
+        let mut num_bytes_builder = UInt64Builder::new(1);
+        num_bytes_builder.append_value(self.num_bytes).unwrap();
+        field_builders.push(Box::new(num_bytes_builder) as Box<dyn ArrayBuilder>);
+
+        let mut null_count_builder = UInt64Builder::new(1);
+        null_count_builder.append_value(self.null_count).unwrap();
+        field_builders.push(Box::new(null_count_builder) as Box<dyn ArrayBuilder>);
+
+        let mut struct_builder = StructBuilder::new(vec![self.arrow_struct_repr()], field_builders);
+        Arc::new(struct_builder.finish())
+    }
+
+    pub fn from_arrow_struct_array(struct_array: &StructArray) -> PartitionStats {
+        return PartitionStats {
+            num_rows: struct_array
+                .column_by_name("num_rows")
+                .expect("from_arrow_struct_array expected a field num_rows")
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("from_arrow_struct_array expected num_rows to be a UInt64Array")
+                .value(0)
+                .to_owned(),
+            num_batches: struct_array
+                .column_by_name("num_batches")
+                .expect("from_arrow_struct_array expected a field num_batches")
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("from_arrow_struct_array expected num_batches to be a UInt64Array")
+                .value(0)
+                .to_owned(),
+            num_bytes: struct_array
+                .column_by_name("num_bytes")
+                .expect("from_arrow_struct_array expected a field num_bytes")
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("from_arrow_struct_array expected num_bytes to be a UInt64Array")
+                .value(0)
+                .to_owned(),
+            null_count: struct_array
+                .column_by_name("null_count")
+                .expect("from_arrow_struct_array expected a field null_count")
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("from_arrow_struct_array expected null_count to be a UInt64Array")
+                .value(0)
+                .to_owned(),
+        };
+    }
 }
 
 /// Stream data to disk in Arrow IPC format
@@ -79,10 +178,10 @@ pub async fn write_stream_to_disk(
     }
     writer.finish()?;
     Ok(PartitionStats {
-        num_rows,
+        num_rows: num_rows as u64,
         num_batches,
-        num_bytes,
-        null_count,
+        num_bytes: num_bytes as u64,
+        null_count: null_count as u64,
     })
 }
 

--- a/rust/ballista/src/utils.rs
+++ b/rust/ballista/src/utils.rs
@@ -50,35 +50,20 @@ pub struct PartitionStats {
 }
 
 impl PartitionStats {
-    // pub fn to_hash_map(&self) -> HashMap<String, String>{
-    //     let mut metadata: HashMap<String, String> = HashMap::new();
-    //     metadata.insert("num_rows".to_string(), self.num_rows.to_string());
-    //     metadata.insert("num_batches".to_string(), self.num_batches.to_string());
-    //     metadata.insert("num_bytes".to_string(), self.num_bytes.to_string());
-    //     metadata.insert("null_count".to_string(), self.null_count.to_string());
-    //     return metadata
-    // }
-    //
-    // pub fn from_hash_map(map: &HashMap<String, String>) -> Result<Self>{
-    //     return Ok(PartitionStats {
-    //         num_rows: map.get("num_rows")?.parse()?,
-    //         num_batches: map.get("num_batches")?.parse()?,
-    //         num_bytes: map.get("num_bytes")?.parse()?,
-    //         null_count: map.get("null_count")?.parse()?,
-    //     })
-    // }
-
     pub fn arrow_struct_repr(self) -> Field {
         Field::new(
             "partition_stats",
-            DataType::Struct(vec![
-                Field::new("num_rows", DataType::UInt64, false),
-                Field::new("num_batches", DataType::UInt64, false),
-                Field::new("num_bytes", DataType::UInt64, false),
-                Field::new("null_count", DataType::UInt64, false),
-            ]),
+            DataType::Struct(self.arrow_struct_fields()),
             false,
         )
+    }
+    fn arrow_struct_fields(self) -> Vec<Field> {
+        vec![
+            Field::new("num_rows", DataType::UInt64, false),
+            Field::new("num_batches", DataType::UInt64, false),
+            Field::new("num_bytes", DataType::UInt64, false),
+            Field::new("null_count", DataType::UInt64, false),
+        ]
     }
 
     pub fn to_arrow_arrayref(&self) -> Arc<StructArray> {
@@ -100,7 +85,8 @@ impl PartitionStats {
         null_count_builder.append_value(self.null_count).unwrap();
         field_builders.push(Box::new(null_count_builder) as Box<dyn ArrayBuilder>);
 
-        let mut struct_builder = StructBuilder::new(vec![self.arrow_struct_repr()], field_builders);
+        let mut struct_builder = StructBuilder::new(self.arrow_struct_fields(), field_builders);
+        struct_builder.append(true).unwrap();
         Arc::new(struct_builder.finish())
     }
 


### PR DESCRIPTION
Addresses #557
So far I have stats being returned in the ExecutePartitionResult object. I am not sure how the scheduler should be maintaining state, but I would love to hear thoughts. 
Not sure of the best way to test this. Going to see how it does in CI. 

I may look into writing some integration testing infrastructure in general for Ballista, but not for this issue as it is blocking #563. 