### PR TITLE
Support executing multiple partitions in calls to ExecutePartition

### DIFF
--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -433,7 +433,7 @@ message Action {
 message ExecutePartition {
   string job_uuid = 1;
   uint32 stage_id = 2;
-  uint32 partition_id = 3;
+  repeated uint32 partition_id = 3;
   PhysicalPlanNode plan = 4;
   // The task could need to read partitions from other executors
   repeated PartitionLocation partition_location = 5;

--- a/rust/ballista/src/client.rs
+++ b/rust/ballista/src/client.rs
@@ -67,7 +67,7 @@ impl BallistaClient {
         &mut self,
         job_uuid: Uuid,
         stage_id: usize,
-        partition_id: usize,
+        partition_id: Vec<usize>,
         plan: Arc<dyn ExecutionPlan>,
     ) -> Result<ExecutePartitionResult> {
         let action = Action::ExecutePartition(ExecutePartition {

--- a/rust/ballista/src/client.rs
+++ b/rust/ballista/src/client.rs
@@ -69,7 +69,7 @@ impl BallistaClient {
         stage_id: usize,
         partition_id: Vec<usize>,
         plan: Arc<dyn ExecutionPlan>,
-    ) -> Result<ExecutePartitionResult> {
+    ) -> Result<Vec<ExecutePartitionResult>> {
         let action = Action::ExecutePartition(ExecutePartition {
             job_uuid,
             stage_id,
@@ -80,35 +80,33 @@ impl BallistaClient {
         let stream = self.execute_action(&action).await?;
         let batches = collect(stream).await?;
 
-        if batches.len() != 1 {
-            return Err(BallistaError::General(
-                "execute_partition received wrong number of result batches".to_owned(),
-            ));
-        }
+        batches
+            .iter()
+            .map(|batch| {
+                if batch.num_rows() != 1 {
+                    Err(BallistaError::General(
+                        "execute_partition received wrong number of rows".to_owned(),
+                    ))
+                } else {
+                    let path = batch
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .expect("execute_partition expected column 0 to be a StringArray");
 
-        let batch = &batches[0];
-        if batch.num_rows() != 1 {
-            return Err(BallistaError::General(
-                "execute_partition received wrong number of rows".to_owned(),
-            ));
-        }
+                    let stats = batch
+                        .column(1)
+                        .as_any()
+                        .downcast_ref::<StructArray>()
+                        .expect("execute_partition expected column 1 to be a StructArray");
 
-        let path = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("execute_partition expected column 0 to be a StringArray");
-
-        let stats = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("execute_partition expected column 1 to be a StructArray");
-
-        Ok(ExecutePartitionResult::new(
-            path.value(0),
-            PartitionStats::from_arrow_struct_array(stats),
-        ))
+                    Ok(ExecutePartitionResult::new(
+                        path.value(0),
+                        PartitionStats::from_arrow_struct_array(stats),
+                    ))
+                }
+            })
+            .collect::<Result<Vec<_>>>()
     }
 
     /// Fetch a partition from an executor

--- a/rust/ballista/src/context.rs
+++ b/rust/ballista/src/context.rs
@@ -241,7 +241,7 @@ impl BallistaDataFrame {
             let status = status.and_then(|s| s.status).ok_or_else(|| {
                 BallistaError::Internal("Received empty status message".to_owned())
             })?;
-            let wait_future = tokio::time::sleep(Duration::from_secs(5));
+            let wait_future = tokio::time::sleep(Duration::from_millis(100));
             match status {
                 job_status::Status::Queued(_) => {
                     info!("Job {} still queued...", job_id);

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -89,74 +89,80 @@ impl FlightService for BallistaFlightService {
         match &action {
             BallistaAction::ExecutePartition(partition) => {
                 info!(
-                    "ExecutePartition: job={}, stage={}, partition={}\n{}",
+                    "ExecutePartition: job={}, stage={}, partition={:?}\n{}",
                     partition.job_uuid,
                     partition.stage_id,
                     partition.partition_id,
                     format_plan(partition.plan.as_ref(), 0).map_err(|e| from_ballista_err(&e))?
                 );
 
-                let mut path = PathBuf::from(&self.executor.config.work_dir);
-                path.push(&format!("{}", partition.job_uuid));
-                path.push(&format!("{}", partition.stage_id));
-                path.push(&format!("{}", partition.partition_id));
-                std::fs::create_dir_all(&path)?;
-
-                path.push("data.arrow");
-                let path = path.to_str().unwrap();
-                info!("Writing results to {}", path);
-
-                let now = Instant::now();
-
-                // execute the query partition
-                let mut stream = partition
-                    .plan
-                    .execute(partition.partition_id)
-                    .await
-                    .map_err(|e| from_datafusion_err(&e))?;
-
-                // stream results to disk
-                let info = utils::write_stream_to_disk(&mut stream, &path)
-                    .await
-                    .map_err(|e| from_ballista_err(&e))?;
-
-                info!(
-                    "Executed partition in {} seconds. Statistics: {:?}",
-                    now.elapsed().as_secs(),
-                    info
-                );
-
-                // build result set with summary of the partition execution status
-                let mut c0 = StringBuilder::new(1);
-                c0.append_value(&path).unwrap();
-                let path: ArrayRef = Arc::new(c0.finish());
-
-                let schema = Arc::new(Schema::new(vec![
-                    Field::new("path", DataType::Utf8, false),
-                    info.arrow_struct_repr(),
-                ]));
-                let stats: ArrayRef = info.to_arrow_arrayref();
-                info!("stats len {}", stats.len());
-                info!("[ath] len {}", path.len());
-
-                let results =
-                    vec![RecordBatch::try_new(schema.clone(), vec![path, stats]).unwrap()];
-                // add an initial FlightData message that sends schema
+                let mut flights: Vec<Result<FlightData, Status>> = vec![];
                 let options = arrow::ipc::writer::IpcWriteOptions::default();
-                let schema_flight_data =
-                    arrow_flight::utils::flight_data_from_arrow_schema(schema.as_ref(), &options);
 
-                let mut flights: Vec<Result<FlightData, Status>> = vec![Ok(schema_flight_data)];
+                for part in &partition.partition_id {
+                    let mut path = PathBuf::from(&self.executor.config.work_dir);
+                    path.push(&format!("{}", partition.job_uuid));
+                    path.push(&format!("{}", partition.stage_id));
+                    path.push(&format!("{}", *part));
+                    std::fs::create_dir_all(&path)?;
 
-                let mut batches: Vec<Result<FlightData, Status>> = results
-                    .iter()
-                    .flat_map(|batch| create_flight_iter(batch, &options))
-                    .collect();
+                    path.push("data.arrow");
+                    let path = path.to_str().unwrap();
+                    info!("Writing results to {}", path);
 
-                // append batch vector to schema vector, so that the first message sent is the schema
-                flights.append(&mut batches);
+                    let now = Instant::now();
+
+                    // execute the query partition
+                    let mut stream = partition
+                        .plan
+                        .execute(*part)
+                        .await
+                        .map_err(|e| from_datafusion_err(&e))?;
+
+                    // stream results to disk
+                    let stats = utils::write_stream_to_disk(&mut stream, &path)
+                        .await
+                        .map_err(|e| from_ballista_err(&e))?;
+
+                    info!(
+                        "Executed partition in {} seconds. Statistics: {:?}",
+                        now.elapsed().as_secs(),
+                        stats
+                    );
+
+                    let schema = Arc::new(Schema::new(vec![
+                        Field::new("path", DataType::Utf8, false),
+                        stats.arrow_struct_repr(),
+                    ]));
+
+                    // build result set with summary of the partition execution status
+                    let mut c0 = StringBuilder::new(1);
+                    c0.append_value(&path).unwrap();
+                    let path: ArrayRef = Arc::new(c0.finish());
+
+                    let stats: ArrayRef = stats.to_arrow_arrayref();
+                    let results =
+                        vec![RecordBatch::try_new(schema.clone(), vec![path, stats]).unwrap()];
+
+                    if flights.is_empty() {
+                        // add an initial FlightData message that sends schema
+                        let schema_flight_data = arrow_flight::utils::flight_data_from_arrow_schema(
+                            schema.as_ref(),
+                            &options,
+                        );
+                        flights.push(Ok(schema_flight_data));
+                    }
+
+                    let mut batches: Vec<Result<FlightData, Status>> = results
+                        .iter()
+                        .flat_map(|batch| create_flight_iter(batch, &options))
+                        .collect();
+
+                    // append batch vector to schema vector, so that the first message sent is the schema
+                    flights.append(&mut batches);
+                }
+
                 let output = futures::stream::iter(flights);
-
                 Ok(Response::new(Box::pin(output) as Self::DoGetStream))
             }
             BallistaAction::FetchPartition(partition_id) => {

--- a/rust/ballista/src/executor/flight_service.rs
+++ b/rust/ballista/src/executor/flight_service.rs
@@ -125,7 +125,8 @@ impl FlightService for BallistaFlightService {
                         .map_err(|e| from_ballista_err(&e))?;
 
                     info!(
-                        "Executed partition in {} seconds. Statistics: {:?}",
+                        "Executed partition {} in {} seconds. Statistics: {:?}",
+                        part,
                         now.elapsed().as_secs(),
                         stats
                     );

--- a/rust/ballista/src/scheduler/planner.rs
+++ b/rust/ballista/src/scheduler/planner.rs
@@ -290,27 +290,39 @@ async fn execute_query_stage(
     let _job_uuid = *job_uuid;
     let partition_count = plan.output_partitioning().partition_count();
     let mut meta = Vec::with_capacity(partition_count);
-    for child_partition in 0..partition_count {
-        debug!(
-            "execute_query_stage() stage_id={}, partition_id={}",
-            stage_id, child_partition
-        );
-        let executor_meta = &executors[child_partition % executors.len()];
-        meta.push(PartitionLocation {
-            partition_id: PartitionId::new(_job_uuid, stage_id, child_partition),
-            executor_meta: executor_meta.clone(),
-        });
+
+    let partition_chunks: Vec<Vec<usize>> = (0..partition_count)
+        .collect::<Vec<usize>>()
+        .chunks(partition_count / executors.len())
+        .map(|r| r.to_vec())
+        .collect();
+
+    info!(
+        "Executing query stage with {} chunks of partition ranges",
+        partition_chunks.len()
+    );
+
+    // build metadata for partition locations
+    for i in 0..partition_chunks.len() {
+        let executor_meta = &executors[i % executors.len()];
+        for part in &partition_chunks[i] {
+            meta.push(PartitionLocation {
+                partition_id: PartitionId::new(_job_uuid, stage_id, *part),
+                executor_meta: executor_meta.clone(),
+            });
+        }
     }
 
     let mut executions = Vec::with_capacity(partition_count);
-    for child_partition in 0..partition_count {
+    for i in 0..partition_chunks.len() {
         let _plan = plan.clone();
-        let _executor_meta = executors[child_partition % executors.len()].clone();
+        let executor_meta = executors[i % executors.len()].clone();
+        let partition_ids = partition_chunks[i].to_vec();
         executions.push(tokio::spawn(async move {
             let mut client =
-                BallistaClient::try_new(&_executor_meta.host, _executor_meta.port).await?;
+                BallistaClient::try_new(&executor_meta.host, executor_meta.port).await?;
             client
-                .execute_partition(_job_uuid, stage_id, vec![child_partition], _plan)
+                .execute_partition(_job_uuid, stage_id, partition_ids, _plan)
                 .await
         }));
     }

--- a/rust/ballista/src/scheduler/planner.rs
+++ b/rust/ballista/src/scheduler/planner.rs
@@ -310,7 +310,7 @@ async fn execute_query_stage(
             let mut client =
                 BallistaClient::try_new(&_executor_meta.host, _executor_meta.port).await?;
             client
-                .execute_partition(_job_uuid, stage_id, child_partition, _plan)
+                .execute_partition(_job_uuid, stage_id, vec![child_partition], _plan)
                 .await
         }));
     }

--- a/rust/ballista/src/serde/scheduler/from_proto.rs
+++ b/rust/ballista/src/serde/scheduler/from_proto.rs
@@ -32,7 +32,7 @@ impl TryInto<Action> for protobuf::Action {
                 Ok(Action::ExecutePartition(ExecutePartition::new(
                     parse_job_uuid(&partition.job_uuid)?,
                     partition.stage_id as usize,
-                    partition.partition_id as usize,
+                    partition.partition_id.iter().map(|n| *n as usize).collect(),
                     partition
                         .plan
                         .as_ref()

--- a/rust/ballista/src/serde/scheduler/mod.rs
+++ b/rust/ballista/src/serde/scheduler/mod.rs
@@ -89,9 +89,9 @@ pub struct ExecutePartition {
     pub(crate) job_uuid: Uuid,
     /// Unique ID representing this query stage within the overall query
     pub(crate) stage_id: usize,
-    /// The partition to execute. The same plan could be sent to multiple executors and each
-    /// executor will execute a single partition per QueryStageTask
-    pub(crate) partition_id: usize,
+    /// The partitions to execute. The same plan could be sent to multiple executors and each
+    /// executor will execute a range of partitions per QueryStageTask
+    pub(crate) partition_id: Vec<usize>,
     /// The physical plan for this query stage
     pub(crate) plan: Arc<dyn ExecutionPlan>,
     /// Location of shuffle partitions that this query stage may depend on
@@ -102,7 +102,7 @@ impl ExecutePartition {
     pub fn new(
         job_uuid: Uuid,
         stage_id: usize,
-        partition_id: usize,
+        partition_id: Vec<usize>,
         plan: Arc<dyn ExecutionPlan>,
         shuffle_locations: HashMap<PartitionId, ExecutorMeta>,
     ) -> Self {
@@ -116,7 +116,10 @@ impl ExecutePartition {
     }
 
     pub fn key(&self) -> String {
-        format!("{}.{}.{}", self.job_uuid, self.stage_id, self.partition_id)
+        format!(
+            "{}.{}.{:?}",
+            self.job_uuid, self.stage_id, self.partition_id
+        )
     }
 }
 

--- a/rust/ballista/src/serde/scheduler/to_proto.rs
+++ b/rust/ballista/src/serde/scheduler/to_proto.rs
@@ -44,7 +44,7 @@ impl TryInto<protobuf::ExecutePartition> for ExecutePartition {
         Ok(protobuf::ExecutePartition {
             job_uuid: self.job_uuid.to_string(),
             stage_id: self.stage_id as u32,
-            partition_id: self.partition_id as u32,
+            partition_id: self.partition_id.iter().map(|n| *n as u32).collect(),
             plan: Some(self.plan.try_into()?),
             partition_location: vec![],
         })

--- a/rust/ballista/src/utils.rs
+++ b/rust/ballista/src/utils.rs
@@ -236,16 +236,20 @@ pub fn format_plan(plan: &dyn ExecutionPlan, indent: usize) -> Result<String> {
         let str = format!("{:?}", plan);
         String::from(&str[0..120])
     };
-    Ok(format!(
-        "{}{}\n{}",
-        "  ".repeat(indent),
-        &operator_str,
-        plan.children()
-            .iter()
-            .map(|c| format_plan(c.as_ref(), indent + 1))
-            .collect::<Result<Vec<String>>>()?
-            .join("\n")
-    ))
+
+    let children_str = plan
+        .children()
+        .iter()
+        .map(|c| format_plan(c.as_ref(), indent + 1))
+        .collect::<Result<Vec<String>>>()?
+        .join("\n");
+
+    let indent_str = "  ".repeat(indent);
+    if plan.children().is_empty() {
+        Ok(format!("{}{}{}", indent_str, &operator_str, children_str))
+    } else {
+        Ok(format!("{}{}\n{}", indent_str, &operator_str, children_str))
+    }
 }
 
 pub fn format_agg_expr(expr: &dyn AggregateExpr) -> Result<String> {


### PR DESCRIPTION
With this change, the planner divides partitions up between the available executors and then sends one ExecutePartition request per executor, with a list of partitions to execute.

This makes a huge difference in the case of HashJoinExec, where each instance of the operator will execute the left side once and fetch all the results into RAM. Before this change, this work would happen once per partition, and now it happens once per executor.

I have been able to run a benchmark against SF=100 for the first time since the rewrite. :tada: 

```
Running benchmarks with the following options: BenchmarkOpt { host: "localhost", port: 50050, query: 5, debug: false, iterations: 1, batch_size: 32768, path: "/mnt/tpch/parquet-sf100-partitioned/", file_format: "parquet" }
Running benchmark with query 5:
 select
    n_name,
    sum(l_extendedprice * (1 - l_discount)) as revenue
from
    customer,
    orders,
    lineitem,
    supplier,
    nation,
    region
where
        c_custkey = o_custkey
  and l_orderkey = o_orderkey
  and l_suppkey = s_suppkey
  and c_nationkey = s_nationkey
  and s_nationkey = n_nationkey
  and n_regionkey = r_regionkey
  and r_name = 'ASIA'
  and o_orderdate >= date '1994-01-01'
  and o_orderdate < date '1995-01-01'
group by
    n_name
order by
    revenue desc;
+-----------+-------------------+
| n_name    | revenue           |
+-----------+-------------------+
| VIETNAM   | 5310749966.867103 |
| INDIA     | 5296094837.750372 |
| JAPAN     | 5282184528.825415 |
| CHINA     | 5270934901.560098 |
| INDONESIA | 5270340980.460805 |
+-----------+-------------------+
Query 5 iteration 0 took 72581.7 ms
```

Closes https://github.com/ballista-compute/ballista/issues/569 and https://github.com/ballista-compute/ballista/issues/568.