### PR TITLE
ExecuteLogicalPlan  ->  ExecuteQuery  and allow plain SQL

### DIFF
--- a/rust/ballista/proto/ballista.proto
+++ b/rust/ballista/proto/ballista.proto
@@ -471,8 +471,10 @@ message RegisterExecutorParams {
 message RegisterExecutorResult {}
 
 message ExecuteQueryParams {
-  LogicalPlanNode logical_plan = 1;
-}
+  oneof query {
+    LogicalPlanNode logical_plan = 1;
+    string sql = 2;
+  }}
 
 message ExecuteSqlParams {
   string sql = 1;
@@ -533,7 +535,7 @@ service SchedulerGrpc {
 
   rpc GetFileMetadata (GetFileMetadataParams) returns (GetFileMetadataResult) {}
 
-  rpc ExecuteLogicalPlan (ExecuteQueryParams) returns (ExecuteQueryResult) {}
+  rpc ExecuteQuery (ExecuteQueryParams) returns (ExecuteQueryResult) {}
 
   rpc ExecuteSQL (ExecuteSqlParams) returns (ExecuteQueryResult) {}
 

--- a/rust/ballista/src/context.rs
+++ b/rust/ballista/src/context.rs
@@ -22,7 +22,8 @@ use std::{fs, time::Duration};
 
 use crate::serde::protobuf::scheduler_grpc_client::SchedulerGrpcClient;
 use crate::serde::protobuf::{
-    job_status, ExecuteQueryParams, ExecuteQueryResult, GetJobStatusParams, GetJobStatusResult,
+    execute_query_params::Query, job_status, ExecuteQueryParams, ExecuteQueryResult,
+    GetJobStatusParams, GetJobStatusResult,
 };
 use crate::serde::scheduler::{Action, ExecutorMeta};
 use crate::{client::BallistaClient, serde::scheduler};
@@ -224,8 +225,8 @@ impl BallistaDataFrame {
         let schema: Schema = plan.schema().as_ref().clone().into();
 
         let job_id = scheduler
-            .execute_logical_plan(ExecuteQueryParams {
-                logical_plan: Some((&plan).try_into()?),
+            .execute_query(ExecuteQueryParams {
+                query: Some(Query::LogicalPlan((&plan).try_into()?)),
             })
             .await?
             .into_inner()


### PR DESCRIPTION
Changes `ExecuteLogicalPlan` to `ExecuteQuery` and allows plain SQL strings in addition to logical plans as described in #567.

New to both Rust and the project, any guidance on better/more idiomatic code very welcome.