### PR TITLE
Update Cargo.toml

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,7 +16,7 @@ snmalloc = ["snmalloc-rs"]
 ballista = {path = "../rust/ballista"}
 futures = "0.3"
 snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}
-pyo3 = {version = "0.13", features = ["extension-module", "abi3-py37"]}
+pyo3 = {version = "0.13", features = ["extension-module", "abi3-py36"]}
 tokio = { version = "1.0", features = ["full"] }
 
 # Should be kept in line with datafusion's serde_json

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,7 +16,7 @@ snmalloc = ["snmalloc-rs"]
 ballista = {path = "../rust/ballista"}
 futures = "0.3"
 snmalloc-rs = {version = "0.2", features= ["cache-friendly"], optional = true}
-pyo3 = {version = "0.13", features = ["extension-module", "abi3"]}
+pyo3 = {version = "0.13", features = ["extension-module", "abi3-py37"]}
 tokio = { version = "1.0", features = ["full"] }
 
 # Should be kept in line with datafusion's serde_json


### PR DESCRIPTION
Update of pyo3 dependency for building python wheel
ballista/python$ maturin build --skip-auditwheel --no-sdist

$ cargo -V
cargo 1.52.0-nightly (bf5a5d5e5 2021-02-18)