### PR TITLE
Build binaries with --release with lto by default

### DIFF
--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -19,13 +19,10 @@ ARG RELEASE_FLAG=--release
 # force build.rs to run to generate configure_me code.
 RUN apt-get -y install cmake
 ENV FORCE_REBUILD='true'
-ENV RUSTFLAGS_EXECUTOR='-C lto -C codegen-units=1 -C embed-bitcode'
-ENV RUSTFLAGS=$RUSTFLAGS_EXECUTOR
+ENV RUSTFLAGS='-C lto -C codegen-units=1 -C embed-bitcode'
 ARG EXECUTOR_BUILD_FEATURES='--features snmalloc'
-WORKDIR /tmp/ballista/e xecutor
+WORKDIR /tmp/ballista/executor
 RUN cargo build $RELEASE_FLAG $EXECUTOR_BUILD_FEATURES
-ENV RUSTFLAGS_SCHEDULER=''
-ENV RUSTFLAGS=$RUSTFLAGS_SCHEDULER
 WORKDIR /tmp/ballista
 RUN cargo build $RELEASE_FLAG
 

--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -19,9 +19,13 @@ ARG RELEASE_FLAG=--release
 # force build.rs to run to generate configure_me code.
 RUN apt-get -y install cmake
 ENV FORCE_REBUILD='true'
+ENV RUSTFLAGS_EXECUTOR ='-C lto -C codegen-units=1 -C embed-bitcode'
+ENV RUSTFLAGS=RUSTFLAGS_EXECUTOR
 ARG EXECUTOR_BUILD_FEATURES='--features snmalloc'
 WORKDIR /tmp/ballista/executor
-RUN cargo build $RELEASE_FLAG $EXECUTOR_BUILD_FEATURES 
+RUN cargo build $RELEASE_FLAG $EXECUTOR_BUILD_FEATURES
+ENV RUSTFLAGS_SCHEDULER =''
+ENV RUSTFLAGS=$RUSTFLAGS_SCHEDULER
 WORKDIR /tmp/ballista
 RUN cargo build $RELEASE_FLAG
 

--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -19,7 +19,6 @@ ARG RELEASE_FLAG=--release
 # force build.rs to run to generate configure_me code.
 RUN apt-get -y install cmake
 ENV FORCE_REBUILD='true'
-ENV RUSTFLAGS='-C lto -C codegen-units=1 -C embed-bitcode'
 ARG EXECUTOR_BUILD_FEATURES='--features snmalloc'
 WORKDIR /tmp/ballista/executor
 RUN cargo build $RELEASE_FLAG $EXECUTOR_BUILD_FEATURES

--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -19,12 +19,12 @@ ARG RELEASE_FLAG=--release
 # force build.rs to run to generate configure_me code.
 RUN apt-get -y install cmake
 ENV FORCE_REBUILD='true'
-ENV RUSTFLAGS_EXECUTOR ='-C lto -C codegen-units=1 -C embed-bitcode'
-ENV RUSTFLAGS=RUSTFLAGS_EXECUTOR
+ENV RUSTFLAGS_EXECUTOR='-C lto -C codegen-units=1 -C embed-bitcode'
+ENV RUSTFLAGS=$RUSTFLAGS_EXECUTOR
 ARG EXECUTOR_BUILD_FEATURES='--features snmalloc'
-WORKDIR /tmp/ballista/executor
+WORKDIR /tmp/ballista/e xecutor
 RUN cargo build $RELEASE_FLAG $EXECUTOR_BUILD_FEATURES
-ENV RUSTFLAGS_SCHEDULER =''
+ENV RUSTFLAGS_SCHEDULER=''
 ENV RUSTFLAGS=$RUSTFLAGS_SCHEDULER
 WORKDIR /tmp/ballista
 RUN cargo build $RELEASE_FLAG

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,3 +9,4 @@ members = [
 
 [profile.release]
 lto = true
+codegen-units = 1

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "scheduler",
     "benchmarks/tpch",
 ]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
https://github.com/ballista-compute/ballista/issues/592

Just putting it in the workspace works nicely.
Will do some comparison in benchmarking later, and maybe test with codegen units =1 too