### PR TITLE
println removal in scheduler main

### DIFF
--- a/rust/scheduler/src/main.rs
+++ b/rust/scheduler/src/main.rs
@@ -71,7 +71,6 @@ async fn main() -> Result<()> {
         print_version();
         std::process::exit(0);
     }
-    println!("{}", opt.namespace);
 
     let namespace = opt.namespace;
     let bind_host = opt.bind_host;


### PR DESCRIPTION
Hi, 
I was launching the scheduler from cargo and i saw the `println!` of the of  the namespace

```
❯ cargo run --bin ballista-scheduler                                                                                                                                                                             
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/ballista-scheduler`
ballista
[2021-03-03T21:04:23Z INFO  ballista_scheduler] Ballista v0.4.2-SNAPSHOT Scheduler listening on 0.0.0.0:50050
```

I'm not sure if it's needed. In case not, this PR removes it :)