### PR TITLE
Fix dockerfile

### DIFF
--- a/docker/rust.dockerfile
+++ b/docker/rust.dockerfile
@@ -19,11 +19,11 @@ ARG RELEASE_FLAG=--release
 # force build.rs to run to generate configure_me code.
 RUN apt-get -y install cmake
 ENV FORCE_REBUILD='true'
+RUN cargo build $RELEASE_FLAG
 ARG EXECUTOR_BUILD_FEATURES='--features snmalloc'
 WORKDIR /tmp/ballista/executor
 RUN cargo build $RELEASE_FLAG $EXECUTOR_BUILD_FEATURES
 WORKDIR /tmp/ballista
-RUN cargo build $RELEASE_FLAG
 
 # put the executor on /executor (need to be copied from different places depending on FLAG)
 ENV RELEASE_FLAG=${RELEASE_FLAG}


### PR DESCRIPTION
The non-snmalloc binary was being built after the snmalloc binary, thus ending with a lower performance executor