### PR TITLE
Add debug logging for optimized plan

### DIFF
--- a/rust/lib/src/scheduler/mod.rs
+++ b/rust/lib/src/scheduler/mod.rs
@@ -316,8 +316,6 @@ impl SchedulerGrpc for SchedulerServer {
 
                 let start = Instant::now();
 
-                debug!("Received plan for execution: {:?}", plan);
-
                 let optimized_plan = fail_job!(datafusion_ctx.optimize(&plan).map_err(|e| {
                     let msg = format!("Could not create optimized logical plan: {}", e);
                     error!("{}", msg);

--- a/rust/lib/src/scheduler/mod.rs
+++ b/rust/lib/src/scheduler/mod.rs
@@ -335,8 +335,8 @@ impl SchedulerGrpc for SchedulerServer {
                     }));
 
                 info!(
-                    "DataFusion created physical plan in {} seconds",
-                    start.elapsed().as_secs(),
+                    "DataFusion created physical plan in {} milliseconds",
+                    start.elapsed().as_millis(),
                 );
 
                 // create distributed physical plan using Ballista

--- a/rust/lib/src/scheduler/mod.rs
+++ b/rust/lib/src/scheduler/mod.rs
@@ -319,7 +319,7 @@ impl SchedulerGrpc for SchedulerServer {
                 debug!("Received plan for execution: {:?}", plan);
 
                 let optimized_plan = fail_job!(datafusion_ctx.optimize(&plan).map_err(|e| {
-                    let msg = format!("Could not create physical plan: {}", e);
+                    let msg = format!("Could not create optimized logical plan: {}", e);
                     error!("{}", msg);
                     tonic::Status::internal(msg)
                 }));


### PR DESCRIPTION
Adds some more debug logging for showing optimized plan being created in Ballista.

This can help with identifying suboptimal logical plans.

Another change is to log millis instead of seconds in physical plan creation (>= 500ms would be very slow already)

Looks like this:
```
ballista-scheduler_1   | [2021-03-05T22:35:10Z DEBUG ballista::scheduler] Calculated optimized plan: Sort: #l_returnflag ASC NULLS FIRST, #l_linestatus ASC NULLS FIRST
ballista-scheduler_1   |       Projection: #l_returnflag, #l_linestatus, #SUM(l_quantity) AS sum_qty, #SUM(l_extendedprice) AS sum_base_price, #SUM(l_extendedprice Multiply Int64(1) Minus l_discount) AS sum_disc_price, #SUM(l_extendedprice Multiply Int64(1) Minus l_discount Multiply Int64(1) Plus l_tax) AS sum_charge, #AVG(l_quantity) AS avg_qty, #AVG(l_extendedprice) AS avg_price, #AVG(l_discount) AS avg_disc, #COUNT(UInt8(1)) AS count_order
ballista-scheduler_1   |         Aggregate: groupBy=[[#l_returnflag, #l_linestatus]], aggr=[[SUM(#l_quantity), SUM(#l_extendedprice), SUM(#l_extendedprice Multiply Int64(1) Minus #l_discount), SUM(#l_extendedprice Multiply Int64(1) Minus #l_discount Multiply Int64(1) Plus #l_tax), AVG(#l_quantity), AVG(#l_extendedprice), AVG(#l_discount), COUNT(UInt8(1))]]
ballista-scheduler_1   |           Filter: #l_shipdate LtEq CAST(Utf8("1998-09-02") AS Date32)
ballista-scheduler_1   |             TableScan: projection=Some([4, 5, 6, 7, 8, 9, 10])
```