### PR TITLE
Implement partition statistics

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,5 +9,5 @@ members = [
 ]
 
 [profile.release]
-lto = true
-codegen-units = 1
+#lto = true
+#codegen-units = 1

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,5 +9,5 @@ members = [
 ]
 
 [profile.release]
-#lto = true
-#codegen-units = 1
+lto = true
+codegen-units = 1

--- a/rust/core/proto/ballista.proto
+++ b/rust/core/proto/ballista.proto
@@ -461,8 +461,10 @@ message PartitionId {
 }
 
 message PartitionStats {
-  uint32 row_count = 1;
-  repeated ColumnStats column_stats = 2;
+  uint64 num_rows = 1;
+  uint64 num_batches = 2;
+  uint64 num_bytes = 3;
+  repeated ColumnStats column_stats = 4;
 }
 
 message ColumnStats {

--- a/rust/core/proto/ballista.proto
+++ b/rust/core/proto/ballista.proto
@@ -461,9 +461,9 @@ message PartitionId {
 }
 
 message PartitionStats {
-  uint64 num_rows = 1;
-  uint64 num_batches = 2;
-  uint64 num_bytes = 3;
+  int64 num_rows = 1;
+  int64 num_batches = 2;
+  int64 num_bytes = 3;
   repeated ColumnStats column_stats = 4;
 }
 

--- a/rust/core/proto/ballista.proto
+++ b/rust/core/proto/ballista.proto
@@ -450,6 +450,7 @@ message ExecutePartition {
 message PartitionLocation {
   PartitionId partition_id = 1;
   ExecutorMetadata executor_meta = 2;
+  PartitionStats partition_stats = 3;
 }
 
 // Unique identifier for a materialized partition of data
@@ -457,6 +458,18 @@ message PartitionId {
   string job_id = 1;
   uint32 stage_id = 2;
   uint32 partition_id = 4;
+}
+
+message PartitionStats {
+  uint32 row_count = 1;
+  repeated ColumnStats column_stats = 2;
+}
+
+message ColumnStats {
+  ScalarValue min_value = 1;
+  ScalarValue max_value = 2;
+  uint32 null_count = 3;
+  uint32 distinct_count = 4;
 }
 
 message ExecutorMetadata {

--- a/rust/core/src/client.rs
+++ b/rust/core/src/client.rs
@@ -24,9 +24,10 @@ use std::{
 use crate::error::{ballista_error, BallistaError, Result};
 use crate::memory_stream::MemoryStream;
 use crate::serde::protobuf::{self};
-use crate::serde::scheduler::{Action, ExecutePartition, ExecutePartitionResult, PartitionId};
+use crate::serde::scheduler::{
+    Action, ExecutePartition, ExecutePartitionResult, PartitionId, PartitionStats,
+};
 
-use crate::utils::PartitionStats;
 use arrow::record_batch::RecordBatch;
 use arrow::{
     array::{StringArray, StructArray},

--- a/rust/core/src/serde/scheduler/from_proto.rs
+++ b/rust/core/src/serde/scheduler/from_proto.rs
@@ -17,7 +17,9 @@ use std::{collections::HashMap, convert::TryInto};
 use crate::error::BallistaError;
 use crate::serde::protobuf;
 use crate::serde::protobuf::action::ActionType;
-use crate::serde::scheduler::{Action, ExecutePartition, PartitionId, PartitionLocation};
+use crate::serde::scheduler::{
+    Action, ExecutePartition, PartitionId, PartitionLocation, PartitionStats,
+};
 
 use datafusion::logical_plan::LogicalPlan;
 use uuid::Uuid;
@@ -66,6 +68,12 @@ impl TryInto<PartitionId> for protobuf::PartitionId {
     }
 }
 
+impl Into<PartitionStats> for protobuf::PartitionStats {
+    fn into(self) -> PartitionStats {
+        PartitionStats::new(self.num_rows, self.num_batches, self.num_bytes)
+    }
+}
+
 impl TryInto<PartitionLocation> for protobuf::PartitionLocation {
     type Error = BallistaError;
 
@@ -84,6 +92,14 @@ impl TryInto<PartitionLocation> for protobuf::PartitionLocation {
                 .ok_or_else(|| {
                     BallistaError::General(
                         "executor_meta in PartitionLocation is missing".to_owned(),
+                    )
+                })?
+                .into(),
+            partition_stats: self
+                .partition_stats
+                .ok_or_else(|| {
+                    BallistaError::General(
+                        "partition_stats in PartitionLocation is missing".to_owned(),
                     )
                 })?
                 .into(),

--- a/rust/core/src/serde/scheduler/from_proto.rs
+++ b/rust/core/src/serde/scheduler/from_proto.rs
@@ -70,7 +70,19 @@ impl TryInto<PartitionId> for protobuf::PartitionId {
 
 impl Into<PartitionStats> for protobuf::PartitionStats {
     fn into(self) -> PartitionStats {
-        PartitionStats::new(self.num_rows, self.num_batches, self.num_bytes)
+        PartitionStats::new(
+            foo(self.num_rows),
+            foo(self.num_batches),
+            foo(self.num_bytes),
+        )
+    }
+}
+
+fn foo(n: i64) -> Option<u64> {
+    if n < 0 {
+        None
+    } else {
+        Some(n as u64)
     }
 }
 

--- a/rust/core/src/serde/scheduler/mod.rs
+++ b/rust/core/src/serde/scheduler/mod.rs
@@ -181,11 +181,11 @@ impl PartitionStats {
             .as_any()
             .downcast_ref::<UInt64Array>()
             .expect("from_arrow_struct_array expected num_bytes to be a UInt64Array");
-        return PartitionStats {
+        PartitionStats {
             num_rows: Some(num_rows.value(0).to_owned()),
             num_batches: Some(num_batches.value(0).to_owned()),
             num_bytes: Some(num_bytes.value(0).to_owned()),
-        };
+        }
     }
 }
 

--- a/rust/core/src/serde/scheduler/to_proto.rs
+++ b/rust/core/src/serde/scheduler/to_proto.rs
@@ -76,10 +76,11 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
 
 impl Into<protobuf::PartitionStats> for PartitionStats {
     fn into(self) -> protobuf::PartitionStats {
+        let none_value = -1_i64;
         protobuf::PartitionStats {
-            num_rows: self.num_rows,
-            num_batches: self.num_batches,
-            num_bytes: self.num_bytes,
+            num_rows: self.num_rows.map(|n| n as i64).unwrap_or(none_value),
+            num_batches: self.num_batches.map(|n| n as i64).unwrap_or(none_value),
+            num_bytes: self.num_bytes.map(|n| n as i64).unwrap_or(none_value),
             column_stats: vec![],
         }
     }

--- a/rust/core/src/serde/scheduler/to_proto.rs
+++ b/rust/core/src/serde/scheduler/to_proto.rs
@@ -67,6 +67,7 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
         Ok(protobuf::PartitionLocation {
             partition_id: Some(self.partition_id.into()),
             executor_meta: Some(self.executor_meta.into()),
+            partition_stats: None,
         })
     }
 }

--- a/rust/core/src/serde/scheduler/to_proto.rs
+++ b/rust/core/src/serde/scheduler/to_proto.rs
@@ -17,7 +17,9 @@ use std::convert::TryInto;
 use crate::error::BallistaError;
 use crate::serde::protobuf;
 use crate::serde::protobuf::action::ActionType;
-use crate::serde::scheduler::{Action, ExecutePartition, PartitionId, PartitionLocation};
+use crate::serde::scheduler::{
+    Action, ExecutePartition, PartitionId, PartitionLocation, PartitionStats,
+};
 
 impl TryInto<protobuf::Action> for Action {
     type Error = BallistaError;
@@ -67,7 +69,18 @@ impl TryInto<protobuf::PartitionLocation> for PartitionLocation {
         Ok(protobuf::PartitionLocation {
             partition_id: Some(self.partition_id.into()),
             executor_meta: Some(self.executor_meta.into()),
-            partition_stats: None,
+            partition_stats: Some(self.partition_stats.into()),
         })
+    }
+}
+
+impl Into<protobuf::PartitionStats> for PartitionStats {
+    fn into(self) -> protobuf::PartitionStats {
+        protobuf::PartitionStats {
+            num_rows: self.num_rows,
+            num_batches: self.num_batches,
+            num_bytes: self.num_bytes,
+            column_stats: vec![],
+        }
     }
 }

--- a/rust/core/src/utils.rs
+++ b/rust/core/src/utils.rs
@@ -77,9 +77,9 @@ pub async fn write_stream_to_disk(
     }
     writer.finish()?;
     Ok(PartitionStats::new(
-        num_rows as u64,
-        num_batches,
-        num_bytes as u64,
+        Some(num_rows as u64),
+        Some(num_batches),
+        Some(num_bytes as u64),
     ))
 }
 

--- a/rust/core/src/utils.rs
+++ b/rust/core/src/utils.rs
@@ -22,6 +22,7 @@ use std::{fs::File, pin::Pin};
 use crate::error::{BallistaError, Result};
 use crate::execution_plans::{QueryStageExec, UnresolvedShuffleExec};
 use crate::memory_stream::MemoryStream;
+use crate::serde::scheduler::PartitionStats;
 use arrow::array::{
     ArrayBuilder, ArrayRef, StructArray, StructBuilder, UInt64Array, UInt64Builder,
 };
@@ -43,105 +44,6 @@ use datafusion::physical_plan::sort::SortExec;
 use datafusion::physical_plan::{AggregateExpr, ExecutionPlan, PhysicalExpr, RecordBatchStream};
 use futures::StreamExt;
 
-/// Summary of executed partition
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionStats {
-    num_rows: u64,
-    num_batches: u64,
-    num_bytes: u64,
-    null_count: u64,
-}
-
-impl Default for PartitionStats {
-    fn default() -> Self {
-        Self {
-            num_rows: 0,
-            num_batches: 0,
-            num_bytes: 0,
-            null_count: 0,
-        }
-    }
-}
-
-impl PartitionStats {
-    pub fn arrow_struct_repr(self) -> Field {
-        Field::new(
-            "partition_stats",
-            DataType::Struct(self.arrow_struct_fields()),
-            false,
-        )
-    }
-    fn arrow_struct_fields(self) -> Vec<Field> {
-        vec![
-            Field::new("num_rows", DataType::UInt64, false),
-            Field::new("num_batches", DataType::UInt64, false),
-            Field::new("num_bytes", DataType::UInt64, false),
-            Field::new("null_count", DataType::UInt64, false),
-        ]
-    }
-
-    pub fn to_arrow_arrayref(&self) -> Arc<StructArray> {
-        let mut field_builders = Vec::new();
-
-        let mut num_rows_builder = UInt64Builder::new(1);
-        num_rows_builder.append_value(self.num_rows).unwrap();
-        field_builders.push(Box::new(num_rows_builder) as Box<dyn ArrayBuilder>);
-
-        let mut num_batches_builder = UInt64Builder::new(1);
-        num_batches_builder.append_value(self.num_batches).unwrap();
-        field_builders.push(Box::new(num_batches_builder) as Box<dyn ArrayBuilder>);
-
-        let mut num_bytes_builder = UInt64Builder::new(1);
-        num_bytes_builder.append_value(self.num_bytes).unwrap();
-        field_builders.push(Box::new(num_bytes_builder) as Box<dyn ArrayBuilder>);
-
-        let mut null_count_builder = UInt64Builder::new(1);
-        null_count_builder.append_value(self.null_count).unwrap();
-        field_builders.push(Box::new(null_count_builder) as Box<dyn ArrayBuilder>);
-
-        let mut struct_builder = StructBuilder::new(self.arrow_struct_fields(), field_builders);
-        struct_builder.append(true).unwrap();
-        Arc::new(struct_builder.finish())
-    }
-
-    pub fn from_arrow_struct_array(struct_array: &StructArray) -> PartitionStats {
-        return PartitionStats {
-            num_rows: struct_array
-                .column_by_name("num_rows")
-                .expect("from_arrow_struct_array expected a field num_rows")
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .expect("from_arrow_struct_array expected num_rows to be a UInt64Array")
-                .value(0)
-                .to_owned(),
-            num_batches: struct_array
-                .column_by_name("num_batches")
-                .expect("from_arrow_struct_array expected a field num_batches")
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .expect("from_arrow_struct_array expected num_batches to be a UInt64Array")
-                .value(0)
-                .to_owned(),
-            num_bytes: struct_array
-                .column_by_name("num_bytes")
-                .expect("from_arrow_struct_array expected a field num_bytes")
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .expect("from_arrow_struct_array expected num_bytes to be a UInt64Array")
-                .value(0)
-                .to_owned(),
-            null_count: struct_array
-                .column_by_name("null_count")
-                .expect("from_arrow_struct_array expected a field null_count")
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .expect("from_arrow_struct_array expected null_count to be a UInt64Array")
-                .value(0)
-                .to_owned(),
-        };
-    }
-}
-
 /// Stream data to disk in Arrow IPC format
 
 pub async fn write_stream_to_disk(
@@ -158,7 +60,6 @@ pub async fn write_stream_to_disk(
     let mut num_rows = 0;
     let mut num_batches = 0;
     let mut num_bytes = 0;
-    let mut null_count = 0;
     let mut writer = FileWriter::try_new(file, stream.schema().as_ref())?;
 
     while let Some(result) = stream.next().await {
@@ -169,20 +70,17 @@ pub async fn write_stream_to_disk(
             .iter()
             .map(|array| array.get_array_memory_size())
             .sum();
-        let batch_null_count: usize = batch.columns().iter().map(|array| array.null_count()).sum();
         num_batches += 1;
         num_rows += batch.num_rows();
         num_bytes += batch_size_bytes;
-        null_count += batch_null_count;
         writer.write(&batch)?;
     }
     writer.finish()?;
-    Ok(PartitionStats {
-        num_rows: num_rows as u64,
+    Ok(PartitionStats::new(
+        num_rows as u64,
         num_batches,
-        num_bytes: num_bytes as u64,
-        null_count: null_count as u64,
-    })
+        num_bytes as u64,
+    ))
 }
 
 pub async fn collect_stream(

--- a/rust/executor/src/flight_service.rs
+++ b/rust/executor/src/flight_service.rs
@@ -23,8 +23,8 @@ use std::time::Instant;
 use crate::BallistaExecutor;
 use ballista_core::error::BallistaError;
 use ballista_core::serde::decode_protobuf;
-use ballista_core::serde::scheduler::Action as BallistaAction;
-use ballista_core::utils::{self, format_plan, PartitionStats};
+use ballista_core::serde::scheduler::{Action as BallistaAction, PartitionStats};
+use ballista_core::utils::{self, format_plan};
 
 use arrow::array::{ArrayRef, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema};

--- a/rust/executor/src/flight_service.rs
+++ b/rust/executor/src/flight_service.rs
@@ -145,7 +145,7 @@ impl FlightService for BallistaFlightService {
                         c0.append_value(&path).unwrap();
                         let path: ArrayRef = Arc::new(c0.finish());
 
-                        let stats: ArrayRef = stats.to_arrow_arrayref();
+                        let stats: ArrayRef = stats.to_arrow_arrayref()?;
                         let results =
                             vec![RecordBatch::try_new(schema, vec![path, stats]).unwrap()];
 

--- a/rust/scheduler/src/planner.rs
+++ b/rust/scheduler/src/planner.rs
@@ -23,7 +23,7 @@ use std::{collections::HashMap, future::Future};
 use ballista_core::client::BallistaClient;
 use ballista_core::datasource::DFTableAdapter;
 use ballista_core::error::{BallistaError, Result};
-use ballista_core::serde::scheduler::ExecutorMeta;
+use ballista_core::serde::scheduler::{ExecutorMeta, PartitionStats};
 use ballista_core::serde::scheduler::PartitionId;
 use ballista_core::{
     execution_plans::{QueryStageExec, ShuffleReaderExec, UnresolvedShuffleExec},
@@ -291,6 +291,7 @@ async fn execute_query_stage(
     );
 
     let partition_count = plan.output_partitioning().partition_count();
+    let mut meta = Vec::with_capacity(partition_count);
 
     let num_chunks = partition_count / executors.len();
     let num_chunks = num_chunks.max(1);
@@ -305,8 +306,19 @@ async fn execute_query_stage(
         partition_chunks.len()
     );
 
-    let mut executions: Vec<JoinHandle<Result<Vec<PartitionLocation>>>> =
-        Vec::with_capacity(partition_count);
+    // build metadata for partition locations
+    for i in 0..partition_chunks.len() {
+        let executor_meta = &executors[i % executors.len()];
+        for part in &partition_chunks[i] {
+            meta.push(PartitionLocation {
+                partition_id: PartitionId::new(job_id, stage_id, *part),
+                executor_meta: executor_meta.clone(),
+                partition_stats: PartitionStats::default()
+            });
+        }
+    }
+
+    let mut executions = Vec::with_capacity(partition_count);
     for i in 0..partition_chunks.len() {
         let plan = plan.clone();
         let executor_meta = executors[i % executors.len()].clone();
@@ -315,18 +327,21 @@ async fn execute_query_stage(
         executions.push(tokio::spawn(async move {
             let mut client =
                 BallistaClient::try_new(&executor_meta.host, executor_meta.port).await?;
-            let stats = client
-                .execute_partition(job_id.clone(), stage_id, partition_ids.clone(), plan)
-                .await?;
-            let mut meta: Vec<PartitionLocation> = Vec::with_capacity(partition_ids.len());
-            for part in &partition_ids {
-                meta.push(PartitionLocation {
-                    partition_id: PartitionId::new(&job_id, stage_id, *part),
-                    executor_meta: executor_meta.clone(),
-                    partition_stats: *stats[*part].statistics(),
-                });
-            }
-            Ok(meta)
+            // let stats = client
+            //     .execute_partition(job_id.clone(), stage_id, partition_ids.clone(), plan)
+            //     .await?;
+            // let mut meta: Vec<PartitionLocation> = Vec::with_capacity(partition_ids.len());
+            // for part in &partition_ids {
+            //     meta.push(PartitionLocation {
+            //         partition_id: PartitionId::new(&job_id, stage_id, *part),
+            //         executor_meta: executor_meta.clone(),
+            //         partition_stats: *stats[*part].statistics(),
+            //     });
+            // }
+            // Ok(meta)
+            client
+                .execute_partition(job_id, stage_id, partition_ids, plan)
+                .await
         }));
     }
 
@@ -334,13 +349,13 @@ async fn execute_query_stage(
     let results = futures::future::join_all(executions).await;
 
     // check for errors
-    let mut meta = Vec::with_capacity(partition_count);
+    // mut meta = Vec::with_capacity(partition_count);
     for result in results {
         match result {
             Ok(partition_result) => {
                 let final_result = partition_result?;
                 debug!("Query stage partition result: {:?}", final_result);
-                meta.extend(final_result);
+                //meta.extend(final_result);
             }
             Err(e) => {
                 return Err(BallistaError::General(format!(

--- a/rust/scheduler/src/state/mod.rs
+++ b/rust/scheduler/src/state/mod.rs
@@ -325,6 +325,7 @@ impl SchedulerState {
                     .map(|(status, execution_id)| PartitionLocation {
                         partition_id: status.partition_id.to_owned(),
                         executor_meta: executors.get(execution_id).map(|e| e.clone().into()),
+                        partition_stats: None,
                     })
                     .collect();
                 job_status::Status::Completed(CompletedJob { partition_location })

--- a/rust/scheduler/src/state/mod.rs
+++ b/rust/scheduler/src/state/mod.rs
@@ -31,6 +31,7 @@ use super::planner::remove_unresolved_shuffles;
 mod etcd;
 mod standalone;
 
+use ballista_core::serde::scheduler::PartitionStats;
 pub use etcd::EtcdClient;
 pub use standalone::StandaloneClient;
 
@@ -232,6 +233,7 @@ impl SchedulerState {
                                             .find(|exec| exec.id == executor_id)
                                             .unwrap()
                                             .clone(),
+                                        partition_stats: PartitionStats::new(0, 0, 0),
                                     },
                                 );
                             } else {

--- a/rust/scheduler/src/state/mod.rs
+++ b/rust/scheduler/src/state/mod.rs
@@ -233,7 +233,7 @@ impl SchedulerState {
                                             .find(|exec| exec.id == executor_id)
                                             .unwrap()
                                             .clone(),
-                                        partition_stats: PartitionStats::new(0, 0, 0),
+                                        partition_stats: PartitionStats::default(),
                                     },
                                 );
                             } else {


### PR DESCRIPTION
Changes in this PR:

- Add `PartitionStats` and `ColumnStats` to protobuf and implement serde code
- Distributed planner now stores partition stats from executed query stages
- Removes `null_count` that I had previously added in `PartitionStats`. This is a column-level statistic not a partition-level statistic so we should add it back once we implement column stats.