### PR TITLE
Update arrow to 46161d2

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
@@ -14,9 +14,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa60d2eadd8b12a996add391db32bd1153eac697ba4869660c0016353611426"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
 dependencies = [
  "getrandom 0.2.2",
  "once_cell",
@@ -77,7 +77,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -98,11 +98,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-flight"
+name = "arrow"
 version = "4.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
 dependencies = [
- "arrow",
+ "cfg_aliases",
+ "chrono",
+ "csv",
+ "flatbuffers",
+ "hex",
+ "indexmap",
+ "lazy_static",
+ "lexical-core",
+ "num",
+ "prettytable-rs",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
+dependencies = [
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
  "bytes",
  "futures",
  "proc-macro2",
@@ -136,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -166,9 +188,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 name = "ballista"
 version = "0.4.2-SNAPSHOT"
 dependencies = [
- "arrow",
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
  "ballista-core",
- "datafusion",
+ "datafusion 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
  "futures",
  "log",
  "tokio",
@@ -178,14 +200,14 @@ dependencies = [
 name = "ballista-core"
 version = "0.4.2-SNAPSHOT"
 dependencies = [
- "arrow",
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
  "arrow-flight",
  "async-trait",
- "datafusion",
+ "datafusion 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
  "futures",
  "log",
  "prost",
- "sqlparser 0.7.0",
+ "sqlparser",
  "tokio",
  "tonic",
  "tonic-build",
@@ -196,10 +218,10 @@ dependencies = [
 name = "ballista-py"
 version = "0.1.0"
 dependencies = [
- "arrow",
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
  "ballista",
  "ballista-core",
- "datafusion",
+ "datafusion 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
  "futures",
  "pyo3",
  "serde",
@@ -413,14 +435,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
- "loom",
  "memoffset",
  "scopeguard",
 ]
@@ -437,21 +458,20 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
- "loom",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -482,10 +502,37 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
+dependencies = [
+ "ahash 0.7.2",
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "async-trait",
+ "chrono",
+ "clap",
+ "futures",
+ "hashbrown",
+ "log",
+ "md-5",
+ "num_cpus",
+ "ordered-float 2.1.1",
+ "parquet 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "paste 1.0.4",
+ "pin-project-lite",
+ "rustyline",
+ "sha2",
+ "sqlparser",
+ "tokio",
+ "tokio-stream",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "datafusion"
+version = "4.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
 dependencies = [
- "ahash 0.7.0",
- "arrow",
+ "ahash 0.7.2",
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
  "async-trait",
  "chrono",
  "clap",
@@ -496,12 +543,12 @@ dependencies = [
  "md-5",
  "num_cpus",
  "ordered-float 2.1.1",
- "parquet",
+ "parquet 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
  "paste 1.0.4",
  "pin-project-lite",
  "rustyline",
  "sha2",
- "sqlparser 0.8.0",
+ "sqlparser",
  "tokio",
 ]
 
@@ -605,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -620,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -630,15 +677,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -647,15 +694,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -665,24 +712,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -696,19 +740,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi",
 ]
 
 [[package]]
@@ -755,16 +786,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
  "bytes",
  "fnv",
@@ -777,7 +802,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -809,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -872,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -985,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libm"
@@ -1011,17 +1035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if 1.0.0",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -1072,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1082,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -1146,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1218,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1284,9 +1297,28 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
+dependencies = [
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "base64 0.12.3",
+ "brotli",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "lz4",
+ "num-bigint",
+ "parquet-format",
+ "snap",
+ "thrift",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
+version = "4.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
 dependencies = [
- "arrow",
+ "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
  "base64 0.12.3",
  "brotli",
  "byteorder",
@@ -1372,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1688,15 +1720,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustyline"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,46 +1747,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1772,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1824,18 +1826,18 @@ checksum = "dc725476a1398f0480d56cd0ad381f6f32acf2642704456f8f59a35df464b59a"
 
 [[package]]
 name = "snmalloc-rs"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef8b05b3ebb9f8ca192bcaee085f57dec601083e90f88bcaf84c2c05c5831a0"
+checksum = "f3cc511c09c88ff9a01d0f2738069f22b3ae3a1438f9074d043e4a8e5bc65127"
 dependencies = [
  "snmalloc-sys",
 ]
 
 [[package]]
 name = "snmalloc-sys"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae09a6102d7aa1f7263eefa5a75ea310fe352f9cc637e633b0e49d853cf8d0f"
+checksum = "ff889eba42bfadff5a6f20001f3691d05b0434f127c600344d808546efd83435"
 dependencies = [
  "cmake",
  "libc",
@@ -1850,15 +1852,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a3da41f3ddf62cbf92635ace62dd037fad9a91c6871c514fbd404e2059f27d"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1884,9 +1877,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2087,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c629c07a3a97f741c140e474e7304294fabec66a43a33f0832e98315ab07f"
+checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2119,9 +2112,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -2279,18 +2272,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zstd"
-version = "0.6.0+zstd.1.4.8"
+version = "0.6.1+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e44664feba7f2f1a9f300c1f6157f2d1bfc3c15c6f3cf4beabf3f5abe9c237"
+checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.0.0+zstd.1.4.8"
+version = "3.0.1+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9447afcd795693ad59918c7bbffe42fdd6e467d708f3537e3dc14dc598c573f"
+checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2298,12 +2291,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.19+zstd.1.4.8"
+version = "1.4.20+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
+checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
 dependencies = [
  "cc",
- "glob",
- "itertools",
  "libc",
 ]

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -98,33 +98,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
-dependencies = [
- "cfg_aliases",
- "chrono",
- "csv",
- "flatbuffers",
- "hex",
- "indexmap",
- "lazy_static",
- "lexical-core",
- "num",
- "prettytable-rs",
- "rand 0.7.3",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "arrow",
  "bytes",
  "futures",
  "proc-macro2",
@@ -188,9 +166,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 name = "ballista"
 version = "0.4.2-SNAPSHOT"
 dependencies = [
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
+ "arrow",
  "ballista-core",
- "datafusion 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
+ "datafusion",
  "futures",
  "log",
  "tokio",
@@ -200,10 +178,10 @@ dependencies = [
 name = "ballista-core"
 version = "0.4.2-SNAPSHOT"
 dependencies = [
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "arrow",
  "arrow-flight",
  "async-trait",
- "datafusion 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "datafusion",
  "futures",
  "log",
  "prost",
@@ -218,10 +196,10 @@ dependencies = [
 name = "ballista-py"
 version = "0.1.0"
 dependencies = [
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "arrow",
  "ballista",
  "ballista-core",
- "datafusion 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "datafusion",
  "futures",
  "pyo3",
  "serde",
@@ -399,64 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,7 +425,7 @@ version = "4.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
  "ahash 0.7.2",
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "arrow",
  "async-trait",
  "chrono",
  "clap",
@@ -515,7 +435,7 @@ dependencies = [
  "md-5",
  "num_cpus",
  "ordered-float 2.1.1",
- "parquet 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
+ "parquet",
  "paste 1.0.4",
  "pin-project-lite",
  "rustyline",
@@ -524,32 +444,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "datafusion"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
-dependencies = [
- "ahash 0.7.2",
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
- "async-trait",
- "chrono",
- "clap",
- "crossbeam",
- "futures",
- "hashbrown",
- "log",
- "md-5",
- "num_cpus",
- "ordered-float 2.1.1",
- "parquet 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
- "paste 1.0.4",
- "pin-project-lite",
- "rustyline",
- "sha2",
- "sqlparser",
- "tokio",
 ]
 
 [[package]]
@@ -1075,15 +969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "memoffset"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,26 +1184,7 @@ name = "parquet"
 version = "4.0.0-SNAPSHOT"
 source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=46161d2)",
- "base64 0.12.3",
- "brotli",
- "byteorder",
- "chrono",
- "flate2",
- "lz4",
- "num-bigint",
- "parquet-format",
- "snap",
- "thrift",
- "zstd",
-]
-
-[[package]]
-name = "parquet"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
-dependencies = [
- "arrow 4.0.0-SNAPSHOT (git+https://github.com/apache/arrow?rev=5647e90)",
+ "arrow",
  "base64 0.12.3",
  "brotli",
  "byteorder",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -25,8 +25,8 @@ tokio = { version = "1.0", features = ["full"] }
 serde_json ="1.0.61"
 serde = { version="1.0", features = ["derive"] }
 
-arrow = { git = "https://github.com/apache/arrow", rev="5647e90" }
-datafusion = { git = "https://github.com/apache/arrow", rev="5647e90" }
+arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
+datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
 
 
 [lib]

--- a/python/src/expression.rs
+++ b/python/src/expression.rs
@@ -108,9 +108,9 @@ impl PyNumberProtocol for BPyExpr {
         })
     }
 
-    fn __invert__(&self) -> PyResult<BPyExpr> {
+    fn __invert__(self) -> PyResult<BPyExpr> {
         Ok(BPyExpr {
-            expr: self.expr.not(),
+            expr: self.expr.clone().not(),
         })
     }
 }
@@ -125,22 +125,22 @@ impl PyObjectProtocol for BPyExpr {
         let other_expr = any_to_expression(other)?;
         Ok(match op {
             CompareOp::Lt => BPyExpr {
-                expr: self.expr.lt(other_expr),
+                expr: self.expr.clone().lt(other_expr),
             },
             CompareOp::Le => BPyExpr {
-                expr: self.expr.lt_eq(other_expr),
+                expr: self.expr.clone().lt_eq(other_expr),
             },
             CompareOp::Eq => BPyExpr {
-                expr: self.expr.eq(other_expr),
+                expr: self.expr.clone().eq(other_expr),
             },
             CompareOp::Ne => BPyExpr {
-                expr: self.expr.not_eq(other_expr),
+                expr: self.expr.clone().not_eq(other_expr),
             },
             CompareOp::Gt => BPyExpr {
-                expr: self.expr.gt(other_expr),
+                expr: self.expr.clone().gt(other_expr),
             },
             CompareOp::Ge => BPyExpr {
-                expr: self.expr.gt_eq(other_expr),
+                expr: self.expr.clone().gt_eq(other_expr),
             },
         })
     }
@@ -159,7 +159,7 @@ impl BPyExpr {
     /// assign a name to the expression
     pub fn alias(&self, name: &str) -> PyResult<BPyExpr> {
         Ok(BPyExpr {
-            expr: self.expr.alias(name),
+            expr: self.expr.clone().alias(name),
         })
     }
     #[args(negated = "false")]

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -64,10 +64,9 @@ pub fn count_distinct(expr: BPyExpr) -> BPyExpr {
 }
 
 #[pyfunction(expr = "*")]
-pub fn concat(expr: &PyTuple) -> PyResult<BPyExpr> {
-    let expressions: Vec<Expr> = util::transform_tuple_to_uniform_type(expr, |e: BPyExpr| e.expr)?;
+pub fn concat(expr: BPyExpr) -> PyResult<BPyExpr> {
     Ok(BPyExpr {
-        expr: logical_plan::concat(expressions),
+        expr: logical_plan::concat(expr.expr),
     })
 }
 

--- a/python/src/functions.rs
+++ b/python/src/functions.rs
@@ -63,7 +63,7 @@ pub fn count_distinct(expr: BPyExpr) -> BPyExpr {
     }
 }
 
-#[pyfunction(expr = "*")]
+#[pyfunction(expr)]
 pub fn concat(expr: BPyExpr) -> PyResult<BPyExpr> {
     Ok(BPyExpr {
         expr: logical_plan::concat(expr.expr),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
  "arrow",
  "bytes",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.45"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3340571769500ddef1e94b45055fabed6b08a881269b7570c830b8f32ef84ef"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -185,7 +185,7 @@ dependencies = [
  "futures",
  "log",
  "prost",
- "sqlparser 0.7.0",
+ "sqlparser",
  "tokio",
  "tonic",
  "tonic-build",
@@ -449,41 +449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,16 +459,6 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -519,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -542,14 +497,13 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
  "async-trait",
  "chrono",
  "clap",
- "crossbeam",
  "futures",
  "hashbrown",
  "log",
@@ -561,8 +515,10 @@ dependencies = [
  "pin-project-lite",
  "rustyline",
  "sha2",
- "sqlparser 0.8.0",
+ "sqlparser",
  "tokio",
+ "tokio-stream",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1311,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow?rev=5647e90#5647e900d597fd7790a4bbb6727e65d6ebdc5569"
+source = "git+https://github.com/apache/arrow?rev=46161d2#46161d26fd439c17cd7c7d2a52d5f8e0b1c14726"
 dependencies = [
  "arrow",
  "base64 0.12.3",
@@ -1727,18 +1683,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1836,15 +1792,6 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a3da41f3ddf62cbf92635ace62dd037fad9a91c6871c514fbd404e2059f27d"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "sqlparser"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b929a9577d01ee7cddb820696ed536868d81557d3c14363a7514d71add1d058"
@@ -1890,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
+checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/benchmarks/tpch/Cargo.toml
+++ b/rust/benchmarks/tpch/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 [dependencies]
 ballista = { path="../../client" }
 
-arrow = { git = "https://github.com/apache/arrow", rev="5647e90" }
-datafusion = { git = "https://github.com/apache/arrow", rev="5647e90" }
-parquet = { git = "https://github.com/apache/arrow", rev="5647e90" }
+arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
+datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
+parquet = { git = "https://github.com/apache/arrow", rev="46161d2" }
 
 
 env_logger = "0.8"

--- a/rust/client/Cargo.toml
+++ b/rust/client/Cargo.toml
@@ -13,5 +13,5 @@ ballista-core = { path = "../core" }
 futures = "0.3"
 log = "0.4"
 tokio = "1.0"
-arrow = { git = "https://github.com/apache/arrow", rev="5647e90" }
-datafusion = { git = "https://github.com/apache/arrow", rev="5647e90" }
+arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
+datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -17,13 +17,13 @@ async-trait = "0.1.36"
 futures = "0.3"
 log = "0.4"
 prost = "0.7"
-sqlparser = "0.7"
+sqlparser = "0.8"
 tokio = "1.0"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-arrow = { git = "https://github.com/apache/arrow", rev="5647e90" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="5647e90" }
-datafusion = { git = "https://github.com/apache/arrow", rev="5647e90" }
+arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="46161d2" }
+datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
 
 
 [dev-dependencies]

--- a/rust/core/proto/ballista.proto
+++ b/rust/core/proto/ballista.proto
@@ -95,7 +95,7 @@ enum ScalarFunction {
   TRUNC = 14;
   ABS = 15;
   SIGNUM = 16;
-  LENGTH = 17;
+  OCTETLENGTH = 17;
   CONCAT = 18;
   LOWER = 19;
   UPPER = 20;

--- a/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/rust/core/src/serde/logical_plan/from_proto.rs
@@ -907,7 +907,7 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
                     protobuf::ScalarFunction::Trunc => Ok(trunc((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Abs => Ok(abs((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Signum => Ok(signum((&expr.expr[0]).try_into()?)),
-                    protobuf::ScalarFunction::Length => Ok(length((&expr.expr[0]).try_into()?)),
+                    protobuf::ScalarFunction::Octetlength => Ok(length((&expr.expr[0]).try_into()?)),
                     // // protobuf::ScalarFunction::Concat => Ok(concat((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Lower => Ok(lower((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Upper => Ok(upper((&expr.expr[0]).try_into()?)),

--- a/rust/core/src/serde/logical_plan/from_proto.rs
+++ b/rust/core/src/serde/logical_plan/from_proto.rs
@@ -907,7 +907,9 @@ impl TryInto<Expr> for &protobuf::LogicalExprNode {
                     protobuf::ScalarFunction::Trunc => Ok(trunc((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Abs => Ok(abs((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Signum => Ok(signum((&expr.expr[0]).try_into()?)),
-                    protobuf::ScalarFunction::Octetlength => Ok(length((&expr.expr[0]).try_into()?)),
+                    protobuf::ScalarFunction::Octetlength => {
+                        Ok(length((&expr.expr[0]).try_into()?))
+                    }
                     // // protobuf::ScalarFunction::Concat => Ok(concat((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Lower => Ok(lower((&expr.expr[0]).try_into()?)),
                     protobuf::ScalarFunction::Upper => Ok(upper((&expr.expr[0]).try_into()?)),

--- a/rust/core/src/serde/logical_plan/to_proto.rs
+++ b/rust/core/src/serde/logical_plan/to_proto.rs
@@ -1181,7 +1181,7 @@ impl TryInto<protobuf::ScalarFunction> for &BuiltinScalarFunction {
             BuiltinScalarFunction::Round => Ok(protobuf::ScalarFunction::Round),
             BuiltinScalarFunction::Trunc => Ok(protobuf::ScalarFunction::Trunc),
             BuiltinScalarFunction::Abs => Ok(protobuf::ScalarFunction::Abs),
-            BuiltinScalarFunction::Length => Ok(protobuf::ScalarFunction::Length),
+            BuiltinScalarFunction::OctetLength => Ok(protobuf::ScalarFunction::Octetlength),
             BuiltinScalarFunction::Concat => Ok(protobuf::ScalarFunction::Concat),
             BuiltinScalarFunction::Lower => Ok(protobuf::ScalarFunction::Lower),
             BuiltinScalarFunction::Upper => Ok(protobuf::ScalarFunction::Upper),

--- a/rust/executor/Cargo.toml
+++ b/rust/executor/Cargo.toml
@@ -28,9 +28,9 @@ tokio-stream = "0.1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 
-arrow = { git = "https://github.com/apache/arrow", rev="5647e90" }
-arrow-flight = { git = "https://github.com/apache/arrow", rev="5647e90" }
-datafusion = { git = "https://github.com/apache/arrow", rev="5647e90" }
+arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
+arrow-flight = { git = "https://github.com/apache/arrow", rev="46161d2" }
+datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
 
 [dev-dependencies]
 

--- a/rust/scheduler/Cargo.toml
+++ b/rust/scheduler/Cargo.toml
@@ -25,8 +25,8 @@ sled = "0.34"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
 tonic = "0.4"
 
-arrow = { git = "https://github.com/apache/arrow", rev="5647e90" }
-datafusion = { git = "https://github.com/apache/arrow", rev="5647e90" }
+arrow = { git = "https://github.com/apache/arrow", rev="46161d2" }
+datafusion = { git = "https://github.com/apache/arrow", rev="46161d2" }
 
 [dev-dependencies]
 ballista-core = { path = "../core" }


### PR DESCRIPTION
* Update arrow to get in some new features / fixes / performance improvements
* Upgrade sqlparser to match upstream (0.8)
* Rename length -> OctetLength//Octetlength
*  change a type in the python bindings